### PR TITLE
Create folder to keep track of database migrations

### DIFF
--- a/supabase/migrations/20260320120000_auth_user_profile_sync_trigger.sql
+++ b/supabase/migrations/20260320120000_auth_user_profile_sync_trigger.sql
@@ -1,0 +1,44 @@
+-- Create profile row when a new auth user is inserted (Supabase standard pattern).
+-- Complements custom_access_token_hook, which only reads profiles for JWT claims.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, full_name, email)
+  VALUES (
+    NEW.id,
+    COALESCE(
+      NULLIF(TRIM(NEW.raw_user_meta_data->>'full_name'), ''),
+      NULLIF(TRIM(NEW.raw_user_meta_data->>'name'), ''),
+      split_part(NEW.email, '@', 1),
+      'User'
+    ),
+    NEW.email
+  );
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.handle_new_user();
+
+-- Backfill any auth users missing a profile (e.g. created before this trigger).
+INSERT INTO public.profiles (id, full_name, email)
+SELECT
+  u.id,
+  COALESCE(
+    NULLIF(TRIM(u.raw_user_meta_data->>'full_name'), ''),
+    NULLIF(TRIM(u.raw_user_meta_data->>'name'), ''),
+    split_part(u.email, '@', 1),
+    'User'
+  ),
+  u.email
+FROM auth.users u
+WHERE NOT EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = u.id);


### PR DESCRIPTION
This commit introduces a new SQL migration that creates a trigger and a function to automatically insert a profile row when a new user is added to the auth.users table. It also backfills existing users who lack a profile, ensuring all users have corresponding profile entries.

Closes #39 