### PR TITLE
Add error handling and response structure for API endpoints

### DIFF
--- a/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
+++ b/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
@@ -6,6 +6,7 @@ import com.gatherly.gatherly_api.service.EventService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -56,9 +57,63 @@ public class EventController {
                                     schema = @Schema(implementation = EventResponse.class)
                             )
                     ),
-                    @ApiResponse(responseCode = "400", description = "Validation failed."),
-                    @ApiResponse(responseCode = "401", description = "Missing or invalid token."),
-                    @ApiResponse(responseCode = "404", description = "Authenticated profile not found.")
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "Validation failed.",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            name = "ValidationError",
+                                            value = """
+                                                    {
+                                                      "timestamp": "2026-03-11T10:00:00Z",
+                                                      "status": 400,
+                                                      "error": "Bad Request",
+                                                      "message": "meetingLink is required for virtual and hybrid events.",
+                                                      "path": "/api/events"
+                                                    }
+                                                    """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "Missing or invalid token.",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            name = "Unauthorized",
+                                            value = """
+                                                    {
+                                                      "timestamp": "2026-03-11T10:00:00Z",
+                                                      "status": 401,
+                                                      "error": "Unauthorized",
+                                                      "message": "Missing or invalid JWT token.",
+                                                      "path": "/api/events"
+                                                    }
+                                                    """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "Authenticated profile not found.",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            name = "ProfileMissing",
+                                            value = """
+                                                    {
+                                                      "timestamp": "2026-03-11T10:00:00Z",
+                                                      "status": 404,
+                                                      "error": "Not Found",
+                                                      "message": "Profile not found for authenticated user.",
+                                                      "path": "/api/events"
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
             }
     )
     public ResponseEntity<EventResponse> createEvent(

--- a/src/main/java/com/gatherly/gatherly_api/dto/ApiErrorResponse.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/ApiErrorResponse.java
@@ -1,0 +1,20 @@
+package com.gatherly.gatherly_api.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Standard JSON shape for API error responses.
+ * <p>
+ * Most errors use the top-level fields. Validation errors can additionally include
+ * field-specific items inside {@code errors}.
+ */
+public record ApiErrorResponse(
+        OffsetDateTime timestamp,
+        int status,
+        String error,
+        String message,
+        String path,
+        List<ApiFieldError> errors
+) {
+}

--- a/src/main/java/com/gatherly/gatherly_api/dto/ApiFieldError.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/ApiFieldError.java
@@ -1,0 +1,7 @@
+package com.gatherly.gatherly_api.dto;
+
+/**
+ * A single field-level validation error in an API error response.
+ */
+public record ApiFieldError(String field, String message) {
+}

--- a/src/main/java/com/gatherly/gatherly_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gatherly/gatherly_api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,104 @@
+package com.gatherly.gatherly_api.exception;
+
+import com.gatherly.gatherly_api.dto.ApiErrorResponse;
+import com.gatherly.gatherly_api.dto.ApiFieldError;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+/**
+ * Converts common API exceptions into a consistent JSON error body.
+ * <p>
+ * Without this advice, some errors can fall back to the default HTML error page
+ * depending on content negotiation (for example requests from Swagger UI).
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ApiErrorResponse> handleResponseStatusException(
+            ResponseStatusException ex,
+            HttpServletRequest request
+    ) {
+        HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
+        String message = ex.getReason() == null ? status.getReasonPhrase() : ex.getReason();
+        return jsonResponse(status, message, request.getRequestURI(), null);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleValidationException(
+            MethodArgumentNotValidException ex,
+            HttpServletRequest request
+    ) {
+        List<ApiFieldError> fieldErrors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(err -> new ApiFieldError(
+                        err.getField(),
+                        err.getDefaultMessage() == null ? "Invalid value." : err.getDefaultMessage()
+                ))
+                .toList();
+
+        return jsonResponse(HttpStatus.BAD_REQUEST, "Validation failed.", request.getRequestURI(), fieldErrors);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiErrorResponse> handleUnreadableJson(
+            HttpMessageNotReadableException ex,
+            HttpServletRequest request
+    ) {
+        return jsonResponse(HttpStatus.BAD_REQUEST, "Malformed JSON request body.", request.getRequestURI(), null);
+    }
+
+    @ExceptionHandler({AccessDeniedException.class, AuthorizationDeniedException.class})
+    public ResponseEntity<ApiErrorResponse> handleForbidden(
+            Exception ex,
+            HttpServletRequest request
+    ) {
+        return jsonResponse(HttpStatus.FORBIDDEN, "Forbidden", request.getRequestURI(), null);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiErrorResponse> handleUnexpectedException(
+            Exception ex,
+            HttpServletRequest request
+    ) {
+        return jsonResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "An unexpected error occurred.",
+                request.getRequestURI(),
+                null
+        );
+    }
+
+    private static ResponseEntity<ApiErrorResponse> jsonResponse(
+            HttpStatus status,
+            String message,
+            String path,
+            List<ApiFieldError> errors
+    ) {
+        ApiErrorResponse payload = new ApiErrorResponse(
+                OffsetDateTime.now(ZoneOffset.UTC),
+                status.value(),
+                status.getReasonPhrase(),
+                message,
+                path,
+                errors
+        );
+        return ResponseEntity.status(status)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(payload);
+    }
+}

--- a/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
@@ -18,12 +18,14 @@ import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -44,6 +46,12 @@ class EventControllerTest {
             return new EventService(null, null, null, null, null) {
                 @Override
                 public EventResponse createEvent(UUID organizerId, CreateEventRequest request) {
+                    if ("trigger-service-400".equals(request.title())) {
+                        throw new ResponseStatusException(
+                                org.springframework.http.HttpStatus.BAD_REQUEST,
+                                "meetingLink is required for virtual and hybrid events."
+                        );
+                    }
                     return new EventResponse(
                             EVENT_ID,
                             request.title(),
@@ -206,7 +214,47 @@ class EventControllerTest {
         mockMvc.perform(post("/api/events")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer user")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.TEXT_HTML)
                         .content(body))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("Validation failed."))
+                .andExpect(jsonPath("$.path").value("/api/events"))
+                .andExpect(jsonPath("$.errors[0].field").value("title"));
+    }
+
+    @Test
+    void postEvents_serviceRuleViolation_returns400Json() throws Exception {
+        String body = """
+                {
+                  "title": "trigger-service-400",
+                  "description": "D",
+                  "eventType": "in_person",
+                  "admissionType": "free",
+                  "startTime": "2026-04-01T18:00:00Z",
+                  "endTime": "2026-04-01T21:00:00Z",
+                  "timezone": "America/Toronto",
+                  "addressLine1": "1 St",
+                  "city": "Toronto",
+                  "province": "ON",
+                  "postalCode": "M5V 1A1",
+                  "maxCapacity": 10,
+                  "categoryIds": []
+                }
+                """;
+
+        mockMvc.perform(post("/api/events")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.TEXT_HTML)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("meetingLink is required for virtual and hybrid events."))
+                .andExpect(jsonPath("$.path").value("/api/events"));
     }
 }


### PR DESCRIPTION
This commit introduces a GlobalExceptionHandler to standardize API error responses, including specific handling for validation errors and other common exceptions. It also adds ApiErrorResponse and ApiFieldError DTOs to encapsulate error details. The EventController is updated to provide detailed error examples in the OpenAPI documentation, enhancing the clarity of API responses for clients. Unit tests are added to verify the new error handling behavior.

Fixes #55 and Fixes #56 