### PR TITLE
Add event listing functionality with public endpoint and pagination

### DIFF
--- a/src/main/java/com/gatherly/gatherly_api/config/SecurityConfig.java
+++ b/src/main/java/com/gatherly/gatherly_api/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
                                 "/swagger-ui.html"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/categories").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/events").permitAll()
                         .anyRequest().authenticated()
                 )
                 // Validate JWTs for any endpoint that requires authentication.

--- a/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
+++ b/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
@@ -1,10 +1,12 @@
 package com.gatherly.gatherly_api.controller;
 
 import com.gatherly.gatherly_api.dto.CreateEventRequest;
+import com.gatherly.gatherly_api.dto.EventListResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
 import com.gatherly.gatherly_api.service.EventService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,7 +20,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,7 +39,6 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/events")
 @Tag(name = "Events", description = "Authenticated event endpoints")
-@SecurityRequirement(name = "bearerAuth")
 public class EventController {
 
     private final EventService eventService;
@@ -44,10 +47,36 @@ public class EventController {
         this.eventService = eventService;
     }
 
+    @GetMapping
+    @Operation(
+            summary = "List active events",
+            description = "Returns a paginated list of active events, sorted with hot events first and then by start time.",
+            security = {},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Page of active events.",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = EventListResponse.class)
+                            )
+                    )
+            }
+    )
+    public ResponseEntity<EventListResponse> getEvents(
+            @Parameter(description = "Zero-based page index. Defaults to 0.")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size. Defaults to 25.")
+            @RequestParam(defaultValue = "25") int size
+    ) {
+        return ResponseEntity.ok(eventService.getEvents(page, size));
+    }
+
     @PostMapping
     @Operation(
             summary = "Create a new event",
             description = "Creates an event and sets the authenticated user as the organizer.",
+            security = @SecurityRequirement(name = "bearerAuth"),
             responses = {
                     @ApiResponse(
                             responseCode = "201",

--- a/src/main/java/com/gatherly/gatherly_api/dto/EventListItemResponse.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/EventListItemResponse.java
@@ -1,0 +1,58 @@
+package com.gatherly.gatherly_api.dto;
+
+import com.gatherly.gatherly_api.model.Event;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Lightweight event row used by GET /api/events list responses.
+ */
+public record EventListItemResponse(
+        UUID id,
+        String title,
+        String eventType,
+        String admissionType,
+        BigDecimal admissionFee,
+        OffsetDateTime startTime,
+        OffsetDateTime endTime,
+        String timezone,
+        String city,
+        String province,
+        String coverImageUrl,
+        int rsvpCount,
+        int maxCapacity,
+        boolean isHot,
+        List<String> categories
+) {
+    public static EventListItemResponse from(Event event, List<String> categories) {
+        int rsvpCount = event.getRsvpCount() == null ? 0 : event.getRsvpCount();
+        int maxCapacity = event.getMaxCapacity() == null ? 0 : event.getMaxCapacity();
+        return new EventListItemResponse(
+                event.getId(),
+                event.getTitle(),
+                event.getEventType().name(),
+                event.getAdmissionType().name(),
+                event.getAdmissionFee(),
+                event.getStartTime(),
+                event.getEndTime(),
+                event.getTimezone(),
+                event.getCity(),
+                event.getProvince() == null ? null : event.getProvince().name(),
+                event.getCoverImageUrl(),
+                rsvpCount,
+                maxCapacity,
+                isHot(rsvpCount, maxCapacity),
+                List.copyOf(categories)
+        );
+    }
+
+    private static boolean isHot(int rsvpCount, int maxCapacity) {
+        if (maxCapacity <= 0) {
+            return false;
+        }
+        return rsvpCount * 100L >= maxCapacity * 80L;
+    }
+}

--- a/src/main/java/com/gatherly/gatherly_api/dto/EventListResponse.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/EventListResponse.java
@@ -1,0 +1,15 @@
+package com.gatherly.gatherly_api.dto;
+
+import java.util.List;
+
+/**
+ * Paginated envelope for GET /api/events.
+ */
+public record EventListResponse(
+        List<EventListItemResponse> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/src/main/java/com/gatherly/gatherly_api/repository/EventCategoryRepository.java
+++ b/src/main/java/com/gatherly/gatherly_api/repository/EventCategoryRepository.java
@@ -16,4 +16,9 @@ public interface EventCategoryRepository extends JpaRepository<EventCategory, UU
      * Loads all category links for an event, used when building API responses.
      */
     List<EventCategory> findByEvent_Id(UUID eventId);
+
+    /**
+     * Loads category links for many events in one query to avoid N+1 selects on list pages.
+     */
+    List<EventCategory> findByEvent_IdIn(List<UUID> eventIds);
 }

--- a/src/main/java/com/gatherly/gatherly_api/repository/EventRepository.java
+++ b/src/main/java/com/gatherly/gatherly_api/repository/EventRepository.java
@@ -1,8 +1,12 @@
 package com.gatherly.gatherly_api.repository;
 
 import com.gatherly.gatherly_api.model.Event;
+import com.gatherly.gatherly_api.model.EventStatus;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.UUID;
 
@@ -10,4 +14,22 @@ import java.util.UUID;
  * Persistence access for {@link Event} rows.
  */
 public interface EventRepository extends JpaRepository<Event, UUID> {
+
+    /**
+     * Returns one page of events in a deterministic order:
+     * hot events first (>=80% full), then earlier start time, then id.
+     */
+    @Query("""
+            SELECT e
+            FROM Event e
+            WHERE e.status = :status
+            ORDER BY
+              CASE
+                WHEN (COALESCE(e.rsvpCount, 0) * 100) >= (e.maxCapacity * 80) THEN 1
+                ELSE 0
+              END DESC,
+              e.startTime ASC,
+              e.id ASC
+            """)
+    Page<Event> findByStatusOrderForListing(EventStatus status, Pageable pageable);
 }

--- a/src/main/java/com/gatherly/gatherly_api/service/EventService.java
+++ b/src/main/java/com/gatherly/gatherly_api/service/EventService.java
@@ -1,6 +1,8 @@
 package com.gatherly.gatherly_api.service;
 
 import com.gatherly.gatherly_api.dto.CreateEventRequest;
+import com.gatherly.gatherly_api.dto.EventListItemResponse;
+import com.gatherly.gatherly_api.dto.EventListResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
 import com.gatherly.gatherly_api.model.AdmissionType;
 import com.gatherly.gatherly_api.model.Category;
@@ -17,6 +19,8 @@ import com.gatherly.gatherly_api.repository.ProfileRepository;
 import jakarta.persistence.EntityManager;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
@@ -25,6 +29,8 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +52,9 @@ import java.util.stream.Collectors;
  */
 @Service
 public class EventService {
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 25;
+    private static final int MAX_PAGE_SIZE = 100;
 
     /** Looks up the organizer’s {@link Profile} row (the user id from the JWT). */
     private final ProfileRepository profileRepository;
@@ -117,6 +126,38 @@ public class EventService {
 
         List<String> categoryNames = categories.stream().map(Category::getName).toList();
         return EventResponse.from(saved, categoryNames);
+    }
+
+    /**
+     * Returns one page of public event listings (active only).
+     * <p>
+     * Sorting is handled by the repository query to keep paging stable:
+     * hot events first, then start time.
+     */
+    @Transactional(readOnly = true)
+    public EventListResponse getEvents(int page, int size) {
+        int normalizedPage = Math.max(page, DEFAULT_PAGE);
+        int normalizedSize = normalizeSize(size);
+        PageRequest pageable = PageRequest.of(normalizedPage, normalizedSize);
+
+        Page<Event> eventsPage = eventRepository.findByStatusOrderForListing(EventStatus.active, pageable);
+        List<Event> events = eventsPage.getContent();
+        Map<UUID, List<String>> categoriesByEventId = loadCategoryNamesByEventId(events);
+
+        List<EventListItemResponse> content = events.stream()
+                .map(event -> EventListItemResponse.from(
+                        event,
+                        categoriesByEventId.getOrDefault(event.getId(), List.of())
+                ))
+                .toList();
+
+        return new EventListResponse(
+                content,
+                eventsPage.getNumber(),
+                eventsPage.getSize(),
+                eventsPage.getTotalElements(),
+                eventsPage.getTotalPages()
+        );
     }
 
     /**
@@ -308,5 +349,43 @@ public class EventService {
     /** Empty or whitespace-only optional strings become {@code null} so we store clean SQL {@code NULL}s. */
     private static String blankToNull(String value) {
         return isBlank(value) ? null : value.trim();
+    }
+
+    private static int normalizeSize(int size) {
+        if (size <= 0) {
+            return DEFAULT_SIZE;
+        }
+        return Math.min(size, MAX_PAGE_SIZE);
+    }
+
+    private List<String> sortedCategoryNamesForEvent(List<EventCategory> linksForEvent) {
+        return linksForEvent.stream()
+                .filter(link -> link.getCategory() != null && link.getCategory().getName() != null)
+                .sorted(Comparator.comparing(EventCategory::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .map(link -> link.getCategory().getName())
+                .toList();
+    }
+
+    private Map<UUID, List<String>> loadCategoryNamesByEventId(List<Event> events) {
+        if (events.isEmpty()) {
+            return Map.of();
+        }
+        List<UUID> eventIds = events.stream().map(Event::getId).toList();
+        List<EventCategory> links = eventCategoryRepository.findByEvent_IdIn(eventIds);
+
+        Map<UUID, List<EventCategory>> linksByEventId = links.stream()
+                .filter(link -> link.getEvent() != null && link.getEvent().getId() != null)
+                .collect(Collectors.groupingBy(
+                        link -> link.getEvent().getId(),
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+
+        Map<UUID, List<String>> namesByEventId = new LinkedHashMap<>();
+        for (UUID eventId : eventIds) {
+            List<EventCategory> linksForEvent = linksByEventId.getOrDefault(eventId, List.of());
+            namesByEventId.put(eventId, sortedCategoryNamesForEvent(linksForEvent));
+        }
+        return namesByEventId;
     }
 }

--- a/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
@@ -3,6 +3,8 @@ package com.gatherly.gatherly_api.controller;
 import com.gatherly.gatherly_api.config.SecurityConfig;
 import com.gatherly.gatherly_api.dto.CreateEventRequest;
 import com.gatherly.gatherly_api.dto.EventAddressResponse;
+import com.gatherly.gatherly_api.dto.EventListItemResponse;
+import com.gatherly.gatherly_api.dto.EventListResponse;
 import com.gatherly.gatherly_api.dto.EventOrganizerResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
 import com.gatherly.gatherly_api.service.EventService;
@@ -21,9 +23,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -44,6 +48,33 @@ class EventControllerTest {
         @Bean
         EventService eventService() {
             return new EventService(null, null, null, null, null) {
+                @Override
+                public EventListResponse getEvents(int page, int size) {
+                    return new EventListResponse(
+                            List.of(new EventListItemResponse(
+                                    EVENT_ID,
+                                    "Spring Meetup 2026",
+                                    "in_person",
+                                    "free",
+                                    null,
+                                    OffsetDateTime.parse("2026-04-01T18:00:00Z"),
+                                    OffsetDateTime.parse("2026-04-01T21:00:00Z"),
+                                    "America/Toronto",
+                                    "Toronto",
+                                    "ON",
+                                    null,
+                                    42,
+                                    50,
+                                    true,
+                                    List.of("Meetup", "Tech")
+                            )),
+                            page,
+                            size,
+                            1,
+                            1
+                    );
+                }
+
                 @Override
                 public EventResponse createEvent(UUID organizerId, CreateEventRequest request) {
                     if ("trigger-service-400".equals(request.title())) {
@@ -136,6 +167,28 @@ class EventControllerTest {
                 .andExpect(jsonPath("$.eventType").value("in_person"))
                 .andExpect(jsonPath("$.rsvpCount").value(0))
                 .andExpect(jsonPath("$.organizer.fullName").value("Jane Doe"));
+    }
+
+    @Test
+    void getEvents_withoutToken_returns200() throws Exception {
+        mockMvc.perform(get("/api/events"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(25))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.content[0].id").value(EVENT_ID.toString()))
+                .andExpect(jsonPath("$.content[0].title").value("Spring Meetup 2026"))
+                .andExpect(jsonPath("$.content[0].isHot").value(true))
+                .andExpect(jsonPath("$.content[0].categories[0]").value("Meetup"));
+    }
+
+    @Test
+    void getEvents_withQueryParams_returnsRequestedPageAndSize() throws Exception {
+        mockMvc.perform(get("/api/events?page=2&size=10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page").value(2))
+                .andExpect(jsonPath("$.size").value(10));
     }
 
     @Test

--- a/src/test/java/com/gatherly/gatherly_api/service/EventServiceTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/service/EventServiceTest.java
@@ -1,10 +1,12 @@
 package com.gatherly.gatherly_api.service;
 
 import com.gatherly.gatherly_api.dto.CreateEventRequest;
+import com.gatherly.gatherly_api.dto.EventListResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
 import com.gatherly.gatherly_api.model.AdmissionType;
 import com.gatherly.gatherly_api.model.Category;
 import com.gatherly.gatherly_api.model.Event;
+import com.gatherly.gatherly_api.model.EventCategory;
 import com.gatherly.gatherly_api.model.EventStatus;
 import com.gatherly.gatherly_api.model.EventType;
 import com.gatherly.gatherly_api.model.Profile;
@@ -20,6 +22,8 @@ import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -367,6 +371,60 @@ class EventServiceTest {
         assertEquals(EventStatus.active, captor.getValue().getStatus());
     }
 
+    @Test
+    void getEvents_returnsMappedPageAndFiltersActiveInRepositoryCall() {
+        Event first = persistedEvent(eventDraft("Hot Event", 80, 100), SAVED_EVENT_ID);
+        Event second = persistedEvent(
+                eventDraft("Warm Event", 10, 100),
+                UUID.fromString("00000000-0000-0000-0000-0000000000bc")
+        );
+        when(eventRepository.findByStatusOrderForListing(
+                org.mockito.ArgumentMatchers.eq(EventStatus.active),
+                any(PageRequest.class)
+        )).thenReturn(new PageImpl<>(List.of(first, second), PageRequest.of(0, 25), 2));
+
+        Category meetup = Category.builder()
+                .id(CATEGORY_ID)
+                .name("Meetup")
+                .slug("meetup")
+                .createdAt(OffsetDateTime.parse("2026-01-01T00:00:00Z"))
+                .build();
+
+        EventCategory firstCategory = EventCategory.builder()
+                .id(UUID.fromString("00000000-0000-0000-0000-000000000031"))
+                .event(first)
+                .category(meetup)
+                .createdAt(OffsetDateTime.parse("2026-01-01T00:00:00Z"))
+                .build();
+
+        when(eventCategoryRepository.findByEvent_IdIn(List.of(first.getId(), second.getId())))
+                .thenReturn(List.of(firstCategory));
+
+        EventListResponse response = eventService.getEvents(0, 25);
+
+        assertEquals(2, response.content().size());
+        assertEquals("Hot Event", response.content().get(0).title());
+        assertEquals(true, response.content().get(0).isHot());
+        assertEquals(List.of("Meetup"), response.content().get(0).categories());
+        assertEquals(List.of(), response.content().get(1).categories());
+        assertEquals(2, response.totalElements());
+    }
+
+    @Test
+    void getEvents_emptyPage_returnsValidEnvelope() {
+        when(eventRepository.findByStatusOrderForListing(
+                org.mockito.ArgumentMatchers.eq(EventStatus.active),
+                any(PageRequest.class)
+        )).thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 25), 0));
+
+        EventListResponse response = eventService.getEvents(0, 25);
+
+        assertEquals(0, response.content().size());
+        assertEquals(0, response.totalElements());
+        assertEquals(0, response.totalPages());
+        verify(eventCategoryRepository, never()).findByEvent_IdIn(anyList());
+    }
+
     private static CreateEventRequest validInPersonRequest(List<UUID> categoryIds) {
         return new CreateEventRequest(
                 "Spring Meetup",
@@ -412,7 +470,7 @@ class EventServiceTest {
                 .startTime(draft.getStartTime())
                 .endTime(draft.getEndTime())
                 .maxCapacity(draft.getMaxCapacity())
-                .rsvpCount(0)
+                .rsvpCount(draft.getRsvpCount())
                 .status(draft.getStatus())
                 .flagReason(draft.getFlagReason())
                 .flaggedBy(draft.getFlaggedBy())
@@ -420,6 +478,30 @@ class EventServiceTest {
                 .deletedAt(draft.getDeletedAt())
                 .createdAt(OffsetDateTime.parse("2026-01-01T12:00:00Z"))
                 .updatedAt(OffsetDateTime.parse("2026-01-01T12:00:00Z"))
+                .build();
+    }
+
+    private static Event eventDraft(String title, int rsvpCount, int maxCapacity) {
+        return Event.builder()
+                .organizer(Profile.builder().id(ORGANIZER_ID).fullName("Jane Doe").build())
+                .title(title)
+                .description("<p>D</p>")
+                .coverImageUrl(null)
+                .eventType(EventType.in_person)
+                .admissionType(AdmissionType.free)
+                .admissionFee(null)
+                .meetingLink(null)
+                .addressLine1("123 Main St")
+                .addressLine2(null)
+                .city("Toronto")
+                .province(Province.ON)
+                .postalCode("M5V 1A1")
+                .timezone("America/Toronto")
+                .startTime(OffsetDateTime.parse("2026-04-01T18:00:00Z"))
+                .endTime(OffsetDateTime.parse("2026-04-01T21:00:00Z"))
+                .maxCapacity(maxCapacity)
+                .rsvpCount(rsvpCount)
+                .status(EventStatus.active)
                 .build();
     }
 }


### PR DESCRIPTION
This commit introduces a new GET endpoint for listing active events, allowing unauthenticated users to access event data. It includes the implementation of pagination and sorting logic in the EventService, along with the necessary DTOs for the response structure. The EventController is updated to handle the new endpoint, and unit tests are added to ensure the functionality works as expected, including validation of query parameters for pagination.

Closes #44 