### PR TITLE
Enhance event retrieval with public access and organizer details

### DIFF
--- a/src/main/java/com/gatherly/gatherly_api/config/SecurityConfig.java
+++ b/src/main/java/com/gatherly/gatherly_api/config/SecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
 
 import com.gatherly.gatherly_api.security.RestAccessDeniedHandler;
@@ -74,16 +76,34 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/categories").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/events").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/events/*").permitAll()
                         .anyRequest().authenticated()
                 )
                 // Validate JWTs for any endpoint that requires authentication.
                 .oauth2ResourceServer(oauth2 -> oauth2
+                        .bearerTokenResolver(publicEventReadBearerTokenResolver())
                         .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter()))
                         // If the token is missing/invalid, Spring will use our JSON 401 handler.
                         .authenticationEntryPoint(authenticationEntryPoint)
                 );
 
         return http.build();
+    }
+
+    /**
+     * Public event reads should not fail on invalid tokens; controller handles token best-effort.
+     */
+    @Bean
+    public BearerTokenResolver publicEventReadBearerTokenResolver() {
+        DefaultBearerTokenResolver delegate = new DefaultBearerTokenResolver();
+        return request -> {
+            String path = request.getRequestURI();
+            String method = request.getMethod();
+            if ("GET".equalsIgnoreCase(method) && path != null && path.matches("^/api/events/[^/]+$")) {
+                return null;
+            }
+            return delegate.resolve(request);
+        };
     }
 }
 

--- a/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
+++ b/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
@@ -16,13 +16,17 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.validation.Valid;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,9 +46,11 @@ import java.util.UUID;
 public class EventController {
 
     private final EventService eventService;
+    private final JwtDecoder jwtDecoder;
 
-    public EventController(EventService eventService) {
+    public EventController(EventService eventService, JwtDecoder jwtDecoder) {
         this.eventService = eventService;
+        this.jwtDecoder = jwtDecoder;
     }
 
     @GetMapping
@@ -70,6 +76,34 @@ public class EventController {
             @RequestParam(defaultValue = "25") int size
     ) {
         return ResponseEntity.ok(eventService.getEvents(page, size));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(
+            summary = "Get event details",
+            description = "Returns full details for one active event. Organizer is included only when a valid JWT is supplied.",
+            security = {},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Event details.",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = EventResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "Event not found or not active."
+                    )
+            }
+    )
+    public ResponseEntity<EventResponse> getEventById(
+            @PathVariable UUID id,
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorizationHeader
+    ) {
+        boolean includeOrganizer = readOptionalUserIdFromAuthorizationHeader(authorizationHeader) != null;
+        return ResponseEntity.ok(eventService.getEventById(id, includeOrganizer));
     }
 
     @PostMapping
@@ -165,6 +199,29 @@ public class EventController {
             return UUID.fromString(jwt.getSubject());
         } catch (IllegalArgumentException exception) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid user subject in token.");
+        }
+    }
+
+    /**
+     * Best-effort JWT parsing for public routes: invalid tokens are treated as anonymous callers.
+     */
+    private UUID readOptionalUserIdFromAuthorizationHeader(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            return null;
+        }
+        String tokenValue = authorizationHeader.substring("Bearer ".length()).trim();
+        if (tokenValue.isEmpty()) {
+            return null;
+        }
+        try {
+            Jwt jwt = jwtDecoder.decode(tokenValue);
+            String subject = jwt.getSubject();
+            if (subject == null || subject.isBlank()) {
+                return null;
+            }
+            return UUID.fromString(subject);
+        } catch (RuntimeException ex) {
+            return null;
         }
     }
 }

--- a/src/main/java/com/gatherly/gatherly_api/repository/EventRepository.java
+++ b/src/main/java/com/gatherly/gatherly_api/repository/EventRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -32,4 +33,9 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
               e.id ASC
             """)
     Page<Event> findByStatusOrderForListing(EventStatus status, Pageable pageable);
+
+    /**
+     * Finds one event by id only when it is in the requested status.
+     */
+    Optional<Event> findByIdAndStatus(UUID id, EventStatus status);
 }

--- a/src/main/java/com/gatherly/gatherly_api/service/EventService.java
+++ b/src/main/java/com/gatherly/gatherly_api/service/EventService.java
@@ -161,6 +161,46 @@ public class EventService {
     }
 
     /**
+     * Loads one active event by id.
+     * <p>
+     * The caller decides whether organizer details should be included.
+     */
+    @Transactional(readOnly = true)
+    public EventResponse getEventById(UUID eventId, boolean includeOrganizer) {
+        Event event = eventRepository.findByIdAndStatus(eventId, EventStatus.active)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found."));
+
+        List<String> categoryNames = eventCategoryRepository.findByEvent_Id(eventId).stream()
+                .filter(link -> link.getCategory() != null && link.getCategory().getName() != null)
+                .sorted(Comparator.comparing(EventCategory::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .map(link -> link.getCategory().getName())
+                .toList();
+
+        EventResponse response = EventResponse.from(event, categoryNames);
+        if (includeOrganizer) {
+            return response;
+        }
+        return new EventResponse(
+                response.id(),
+                response.title(),
+                response.description(),
+                response.eventType(),
+                response.admissionType(),
+                response.admissionFee(),
+                response.startTime(),
+                response.endTime(),
+                response.timezone(),
+                response.address(),
+                response.coverImageUrl(),
+                response.rsvpCount(),
+                response.maxCapacity(),
+                response.isHot(),
+                response.categories(),
+                null
+        );
+    }
+
+    /**
      * Maps the HTTP request DTO into a new {@link Event} entity. New events start as
      * {@link EventStatus#active} with no flag or soft-delete fields set.
      */

--- a/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
@@ -76,6 +76,34 @@ class EventControllerTest {
                 }
 
                 @Override
+                public EventResponse getEventById(UUID eventId, boolean includeOrganizer) {
+                    if (UUID.fromString("00000000-0000-0000-0000-0000000000ff").equals(eventId)) {
+                        throw new ResponseStatusException(
+                                org.springframework.http.HttpStatus.NOT_FOUND,
+                                "Event not found."
+                        );
+                    }
+                    return new EventResponse(
+                            eventId,
+                            "Event Title",
+                            "<p>Detail</p>",
+                            "in_person",
+                            "free",
+                            null,
+                            OffsetDateTime.parse("2026-04-01T18:00:00Z"),
+                            OffsetDateTime.parse("2026-04-01T21:00:00Z"),
+                            "America/Toronto",
+                            new EventAddressResponse("123 Main St", null, "Toronto", "ON", "M5V 1A1"),
+                            "https://example.com/cover.png",
+                            7,
+                            50,
+                            false,
+                            List.of("Meetup"),
+                            includeOrganizer ? new EventOrganizerResponse(USER_ID, "Jane Doe") : null
+                    );
+                }
+
+                @Override
                 public EventResponse createEvent(UUID organizerId, CreateEventRequest request) {
                     if ("trigger-service-400".equals(request.title())) {
                         throw new ResponseStatusException(
@@ -189,6 +217,43 @@ class EventControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.page").value(2))
                 .andExpect(jsonPath("$.size").value(10));
+    }
+
+    @Test
+    void getEventById_withoutToken_returns200WithoutOrganizer() throws Exception {
+        mockMvc.perform(get("/api/events/" + EVENT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(EVENT_ID.toString()))
+                .andExpect(jsonPath("$.title").value("Event Title"))
+                .andExpect(jsonPath("$.organizer").doesNotExist());
+    }
+
+    @Test
+    void getEventById_withValidToken_returns200WithOrganizer() throws Exception {
+        mockMvc.perform(get("/api/events/" + EVENT_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(EVENT_ID.toString()))
+                .andExpect(jsonPath("$.organizer.id").value(USER_ID.toString()));
+    }
+
+    @Test
+    void getEventById_withInvalidToken_treatedAsAnonymous() throws Exception {
+        mockMvc.perform(get("/api/events/" + EVENT_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer invalid"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(EVENT_ID.toString()))
+                .andExpect(jsonPath("$.organizer").doesNotExist());
+    }
+
+    @Test
+    void getEventById_missing_returns404Json() throws Exception {
+        mockMvc.perform(get("/api/events/00000000-0000-0000-0000-0000000000ff")
+                        .accept(MediaType.TEXT_HTML))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.path").value("/api/events/00000000-0000-0000-0000-0000000000ff"));
     }
 
     @Test

--- a/src/test/java/com/gatherly/gatherly_api/service/EventServiceTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/service/EventServiceTest.java
@@ -425,6 +425,60 @@ class EventServiceTest {
         verify(eventCategoryRepository, never()).findByEvent_IdIn(anyList());
     }
 
+    @Test
+    void getEventById_includeOrganizerTrue_returnsOrganizer() {
+        Event event = persistedEvent(eventDraft("Detail Event", 20, 100), SAVED_EVENT_ID);
+        event = persistedEventWithOrganizer(event, organizer);
+        when(eventRepository.findByIdAndStatus(SAVED_EVENT_ID, EventStatus.active)).thenReturn(Optional.of(event));
+
+        Category category = Category.builder()
+                .id(CATEGORY_ID)
+                .name("Meetup")
+                .slug("meetup")
+                .createdAt(OffsetDateTime.parse("2026-01-01T00:00:00Z"))
+                .build();
+        EventCategory link = EventCategory.builder()
+                .id(UUID.fromString("00000000-0000-0000-0000-000000000091"))
+                .event(event)
+                .category(category)
+                .createdAt(OffsetDateTime.parse("2026-01-01T00:00:00Z"))
+                .build();
+        when(eventCategoryRepository.findByEvent_Id(SAVED_EVENT_ID)).thenReturn(List.of(link));
+
+        EventResponse response = eventService.getEventById(SAVED_EVENT_ID, true);
+
+        assertEquals(SAVED_EVENT_ID, response.id());
+        assertEquals("Detail Event", response.title());
+        assertEquals("Meetup", response.categories().get(0));
+        assertEquals(ORGANIZER_ID, response.organizer().id());
+    }
+
+    @Test
+    void getEventById_includeOrganizerFalse_omitsOrganizer() {
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Detail Event", 20, 100), SAVED_EVENT_ID),
+                organizer
+        );
+        when(eventRepository.findByIdAndStatus(SAVED_EVENT_ID, EventStatus.active)).thenReturn(Optional.of(event));
+        when(eventCategoryRepository.findByEvent_Id(SAVED_EVENT_ID)).thenReturn(List.of());
+
+        EventResponse response = eventService.getEventById(SAVED_EVENT_ID, false);
+
+        assertEquals(SAVED_EVENT_ID, response.id());
+        assertEquals(null, response.organizer());
+    }
+
+    @Test
+    void getEventById_missing_throws404() {
+        when(eventRepository.findByIdAndStatus(SAVED_EVENT_ID, EventStatus.active)).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> eventService.getEventById(SAVED_EVENT_ID, false)
+        );
+        assertEquals(NOT_FOUND, ex.getStatusCode());
+    }
+
     private static CreateEventRequest validInPersonRequest(List<UUID> categoryIds) {
         return new CreateEventRequest(
                 "Spring Meetup",
@@ -502,6 +556,37 @@ class EventServiceTest {
                 .maxCapacity(maxCapacity)
                 .rsvpCount(rsvpCount)
                 .status(EventStatus.active)
+                .build();
+    }
+
+    private static Event persistedEventWithOrganizer(Event event, Profile organizerProfile) {
+        return Event.builder()
+                .id(event.getId())
+                .organizer(organizerProfile)
+                .title(event.getTitle())
+                .description(event.getDescription())
+                .coverImageUrl(event.getCoverImageUrl())
+                .eventType(event.getEventType())
+                .admissionType(event.getAdmissionType())
+                .admissionFee(event.getAdmissionFee())
+                .meetingLink(event.getMeetingLink())
+                .addressLine1(event.getAddressLine1())
+                .addressLine2(event.getAddressLine2())
+                .city(event.getCity())
+                .province(event.getProvince())
+                .postalCode(event.getPostalCode())
+                .timezone(event.getTimezone())
+                .startTime(event.getStartTime())
+                .endTime(event.getEndTime())
+                .maxCapacity(event.getMaxCapacity())
+                .rsvpCount(event.getRsvpCount())
+                .status(event.getStatus())
+                .flagReason(event.getFlagReason())
+                .flaggedBy(event.getFlaggedBy())
+                .flaggedAt(event.getFlaggedAt())
+                .deletedAt(event.getDeletedAt())
+                .createdAt(event.getCreatedAt())
+                .updatedAt(event.getUpdatedAt())
                 .build();
     }
 }


### PR DESCRIPTION
This commit adds a new GET endpoint to retrieve event details by ID, allowing unauthenticated users to access event information. The implementation includes a best-effort JWT parsing mechanism to determine if organizer details should be included in the response based on the presence of a valid token. Additionally, the `EventService` is updated to support fetching events by ID with status validation, and corresponding unit tests are added to ensure the functionality works as intended.

Closes #45 