### PR TITLE
Implement organizer dashboard endpoint for event management

### DIFF
--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -401,22 +401,89 @@ Flags an event. Restricted to `moderator` and `admin` roles only.
 ---
 
 #### `GET /events/my`
-Returns all events created by the authenticated user, grouped by status — including active, archived, flagged and soft deleted (within the 7 day window).
+Returns a **complete dashboard view** of every event the authenticated user has created that still exists in the database — more detail than the public listing (`GET /events`) and across all lifecycle states you care about as the organizer.
+
+**Included:**
+
+| Group | Meaning |
+|---|---|
+| **Active** | Live on the public listing; accepting RSVPs. |
+| **Archived** | Past end time; no longer shown on the main public listing. |
+| **Flagged** | Hidden from the public; you still see the event with `flagReason`, `flaggedAt`, and `flaggedBy` so you know why it was flagged. |
+| **Soft deleted** | Only rows still within the **7-day grace** window after `deleted_at` (before a future CRON job purges them permanently). |
+
+**Excluded:**
+
+| Case | Reason |
+|---|---|
+| **Purged** | Hard-deleted from the database — nothing to return. |
+| **Other users’ events** | Scoped strictly to the authenticated organizer. |
+| **Soft deleted (expired grace)** | `deleted_at` is older than 7 days; row may still exist until purge runs, but it does not appear here. |
 
 **Query parameters:**
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `status` | `string` | ❌ | Filter by status: `active`, `archived`, `flagged`, `soft_deleted`. Returns all if omitted. |
-| `page` | `integer` | ❌ | Defaults to `0`. |
-| `size` | `integer` | ❌ | Defaults to `25`. |
+| `status` | `string` | ❌ | Filter to one lifecycle group: `active`, `archived`, `flagged`, `soft_deleted`. Omit to return all groups that pass the rules above. |
+| `page` | `integer` | ❌ | Zero-based page index. Defaults to `0`. |
+| `size` | `integer` | ❌ | Page size. Defaults to `25`. Maximum `100` per request. |
+
+Results are sorted by **`startTime` descending**, then by `id` for a stable order.
 
 **Responses:**
 
 | Status | Description |
 |---|---|
-| `200 OK` | Returns paginated list of the user's events. |
+| `200 OK` | Paginated list of your events (see success body below). |
+| `400 Bad Request` | Invalid `status` query value (not one of the allowed enum labels). |
 | `401 Unauthorized` | Missing or invalid token. |
+
+**Success response body:**
+```json
+{
+  "content": [
+    {
+      "id": "uuid",
+      "title": "Spring Meetup 2026",
+      "description": "<p>Rich text content here...</p>",
+      "eventType": "in_person",
+      "admissionType": "free",
+      "admissionFee": null,
+      "meetingLink": null,
+      "startTime": "2026-04-01T18:00:00Z",
+      "endTime": "2026-04-01T21:00:00Z",
+      "timezone": "America/Toronto",
+      "address": {
+        "addressLine1": "123 Main St",
+        "addressLine2": null,
+        "city": "Toronto",
+        "province": "ON",
+        "postalCode": "M5V 1A1"
+      },
+      "coverImageUrl": "https://res.cloudinary.com/...",
+      "rsvpCount": 42,
+      "maxCapacity": 50,
+      "isHot": true,
+      "categories": ["Meetup", "Tech"],
+      "status": "active",
+      "flagReason": null,
+      "flaggedAt": null,
+      "flaggedBy": null,
+      "deletedAt": null,
+      "organizer": {
+        "id": "uuid",
+        "fullName": "Jane Doe"
+      }
+    }
+  ],
+  "page": 0,
+  "size": 25,
+  "totalElements": 12,
+  "totalPages": 1
+}
+```
+
+> **Notes:** For **flagged** events, `flagReason`, `flaggedAt`, and `flaggedBy` are populated (`flaggedBy` uses the same `{ id, fullName }` shape as the public detail `organizer` block). For **soft deleted** events in grace, `deletedAt` is set and `status` is `soft_deleted`. Virtual/hybrid events include `meetingLink` when present.
 
 ---
 

--- a/src/main/java/com/gatherly/gatherly_api/config/SecurityConfig.java
+++ b/src/main/java/com/gatherly/gatherly_api/config/SecurityConfig.java
@@ -13,11 +13,20 @@ import org.springframework.security.oauth2.server.resource.web.BearerTokenResolv
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
 
+import java.util.regex.Pattern;
+
 import com.gatherly.gatherly_api.security.RestAccessDeniedHandler;
 import com.gatherly.gatherly_api.security.RestAuthenticationEntryPoint;
 
 @Configuration
 public class SecurityConfig {
+
+    /**
+     * Public {@code GET /api/events/{uuid}} only — excludes paths like {@code /api/events/my} so JWTs are validated there.
+     */
+    private static final Pattern PUBLIC_EVENT_DETAIL_PATH = Pattern.compile(
+            "^/api/events/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    );
 
     /**
      * Reads the Supabase JWT claim (named {@code role}) and converts it into
@@ -76,6 +85,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/categories").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/events").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/events/my").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/events/*").permitAll()
                         .anyRequest().authenticated()
                 )
@@ -99,7 +109,7 @@ public class SecurityConfig {
         return request -> {
             String path = request.getRequestURI();
             String method = request.getMethod();
-            if ("GET".equalsIgnoreCase(method) && path != null && path.matches("^/api/events/[^/]+$")) {
+            if ("GET".equalsIgnoreCase(method) && path != null && PUBLIC_EVENT_DETAIL_PATH.matcher(path).matches()) {
                 return null;
             }
             return delegate.resolve(request);

--- a/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
+++ b/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
@@ -3,6 +3,8 @@ package com.gatherly.gatherly_api.controller;
 import com.gatherly.gatherly_api.dto.CreateEventRequest;
 import com.gatherly.gatherly_api.dto.EventListResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
+import com.gatherly.gatherly_api.dto.OrganizerEventListResponse;
+import com.gatherly.gatherly_api.model.EventStatus;
 import com.gatherly.gatherly_api.service.EventService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -76,6 +78,46 @@ public class EventController {
             @RequestParam(defaultValue = "25") int size
     ) {
         return ResponseEntity.ok(eventService.getEvents(page, size));
+    }
+
+    @GetMapping("/my")
+    @Operation(
+            summary = "List my events (organizer dashboard)",
+            description = "All events you created that are not purged (active, archived, flagged, "
+                    + "soft-deleted within the 7-day grace window). Optional status filter. "
+                    + "Sorted by start time, newest first.",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Page of your events.",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = OrganizerEventListResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "Invalid `status` query value."
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "Missing or invalid token."
+                    )
+            }
+    )
+    public ResponseEntity<OrganizerEventListResponse> getMyEvents(
+            @AuthenticationPrincipal Jwt jwt,
+            @Parameter(description = "Filter: active, archived, flagged, soft_deleted. Omit for all.")
+            @RequestParam(required = false) String status,
+            @Parameter(description = "Zero-based page index. Defaults to 0.")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size. Defaults to 25.")
+            @RequestParam(defaultValue = "25") int size
+    ) {
+        UUID organizerId = readUserIdFromJwt(jwt);
+        EventStatus statusFilter = parseOptionalStatusFilter(status);
+        return ResponseEntity.ok(eventService.getMyEvents(organizerId, statusFilter, page, size));
     }
 
     @GetMapping("/{id}")
@@ -199,6 +241,20 @@ public class EventController {
             return UUID.fromString(jwt.getSubject());
         } catch (IllegalArgumentException exception) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid user subject in token.");
+        }
+    }
+
+    /**
+     * Optional {@code status} for GET /my; must match {@link EventStatus} enum names (e.g. {@code soft_deleted}).
+     */
+    private static EventStatus parseOptionalStatusFilter(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return EventStatus.valueOf(raw.trim());
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid status filter.");
         }
     }
 

--- a/src/main/java/com/gatherly/gatherly_api/dto/OrganizerEventItemResponse.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/OrganizerEventItemResponse.java
@@ -1,0 +1,93 @@
+package com.gatherly.gatherly_api.dto;
+
+import com.gatherly.gatherly_api.model.Event;
+import com.gatherly.gatherly_api.model.Profile;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Full event row for the authenticated organizer's dashboard ({@code GET /api/events/my}).
+ * <p>
+ * Includes lifecycle fields that public listings hide (status, flag metadata, soft-delete time).
+ */
+public record OrganizerEventItemResponse(
+        UUID id,
+        String title,
+        String description,
+        String eventType,
+        String admissionType,
+        BigDecimal admissionFee,
+        String meetingLink,
+        OffsetDateTime startTime,
+        OffsetDateTime endTime,
+        String timezone,
+        EventAddressResponse address,
+        String coverImageUrl,
+        int rsvpCount,
+        int maxCapacity,
+        boolean isHot,
+        List<String> categories,
+        String status,
+        String flagReason,
+        OffsetDateTime flaggedAt,
+        EventOrganizerResponse flaggedBy,
+        OffsetDateTime deletedAt,
+        EventOrganizerResponse organizer
+) {
+
+    public static OrganizerEventItemResponse from(Event event, List<String> categoryNames) {
+        Profile organizer = event.getOrganizer();
+        EventOrganizerResponse organizerBlock = organizer == null
+                ? null
+                : new EventOrganizerResponse(organizer.getId(), organizer.getFullName());
+
+        Profile flaggedByProfile = event.getFlaggedBy();
+        EventOrganizerResponse flaggedByBlock = flaggedByProfile == null
+                ? null
+                : new EventOrganizerResponse(flaggedByProfile.getId(), flaggedByProfile.getFullName());
+
+        int rsvp = event.getRsvpCount() == null ? 0 : event.getRsvpCount();
+        int cap = event.getMaxCapacity() == null ? 0 : event.getMaxCapacity();
+
+        return new OrganizerEventItemResponse(
+                event.getId(),
+                event.getTitle(),
+                event.getDescription(),
+                event.getEventType().name(),
+                event.getAdmissionType().name(),
+                event.getAdmissionFee(),
+                event.getMeetingLink(),
+                event.getStartTime(),
+                event.getEndTime(),
+                event.getTimezone(),
+                new EventAddressResponse(
+                        event.getAddressLine1(),
+                        event.getAddressLine2(),
+                        event.getCity(),
+                        event.getProvince() == null ? null : event.getProvince().name(),
+                        event.getPostalCode()
+                ),
+                event.getCoverImageUrl(),
+                rsvp,
+                cap,
+                isHot(rsvp, cap),
+                List.copyOf(categoryNames),
+                event.getStatus().name(),
+                event.getFlagReason() == null ? null : event.getFlagReason().name(),
+                event.getFlaggedAt(),
+                flaggedByBlock,
+                event.getDeletedAt(),
+                organizerBlock
+        );
+    }
+
+    private static boolean isHot(int rsvpCount, int maxCapacity) {
+        if (maxCapacity <= 0) {
+            return false;
+        }
+        return rsvpCount * 100L >= maxCapacity * 80L;
+    }
+}

--- a/src/main/java/com/gatherly/gatherly_api/dto/OrganizerEventListResponse.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/OrganizerEventListResponse.java
@@ -1,0 +1,15 @@
+package com.gatherly.gatherly_api.dto;
+
+import java.util.List;
+
+/**
+ * Paginated envelope for {@code GET /api/events/my}.
+ */
+public record OrganizerEventListResponse(
+        List<OrganizerEventItemResponse> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/src/main/java/com/gatherly/gatherly_api/repository/EventRepository.java
+++ b/src/main/java/com/gatherly/gatherly_api/repository/EventRepository.java
@@ -7,7 +7,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -38,4 +40,76 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
      * Finds one event by id only when it is in the requested status.
      */
     Optional<Event> findByIdAndStatus(UUID id, EventStatus status);
+
+    /**
+     * Organizer dashboard without status filter. Split from the filtered variant so Postgres never sees a
+     * nullable enum parameter (avoids {@code could not determine data type of parameter} on {@code OR} clauses).
+     * <p>
+     * {@code softDeleted} must be {@link EventStatus#soft_deleted}.
+     */
+    @Query(
+            value = """
+                    SELECT e
+                    FROM Event e
+                    WHERE e.organizer.id = :organizerId
+                      AND (
+                        e.status <> :softDeleted
+                        OR e.deletedAt IS NULL
+                        OR e.deletedAt >= :graceCutoff
+                      )
+                    ORDER BY e.startTime DESC, e.id DESC
+                    """,
+            countQuery = """
+                    SELECT COUNT(e)
+                    FROM Event e
+                    WHERE e.organizer.id = :organizerId
+                      AND (
+                        e.status <> :softDeleted
+                        OR e.deletedAt IS NULL
+                        OR e.deletedAt >= :graceCutoff
+                      )
+                    """
+    )
+    Page<Event> findOrganizerDashboardEventsAll(
+            @Param("organizerId") UUID organizerId,
+            @Param("graceCutoff") OffsetDateTime graceCutoff,
+            @Param("softDeleted") EventStatus softDeleted,
+            Pageable pageable
+    );
+
+    /**
+     * Same as {@link #findOrganizerDashboardEventsAll} but restricted to {@code statusFilter}.
+     */
+    @Query(
+            value = """
+                    SELECT e
+                    FROM Event e
+                    WHERE e.organizer.id = :organizerId
+                      AND (
+                        e.status <> :softDeleted
+                        OR e.deletedAt IS NULL
+                        OR e.deletedAt >= :graceCutoff
+                      )
+                      AND e.status = :statusFilter
+                    ORDER BY e.startTime DESC, e.id DESC
+                    """,
+            countQuery = """
+                    SELECT COUNT(e)
+                    FROM Event e
+                    WHERE e.organizer.id = :organizerId
+                      AND (
+                        e.status <> :softDeleted
+                        OR e.deletedAt IS NULL
+                        OR e.deletedAt >= :graceCutoff
+                      )
+                      AND e.status = :statusFilter
+                    """
+    )
+    Page<Event> findOrganizerDashboardEventsFiltered(
+            @Param("organizerId") UUID organizerId,
+            @Param("graceCutoff") OffsetDateTime graceCutoff,
+            @Param("softDeleted") EventStatus softDeleted,
+            @Param("statusFilter") EventStatus statusFilter,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/gatherly/gatherly_api/service/EventService.java
+++ b/src/main/java/com/gatherly/gatherly_api/service/EventService.java
@@ -4,6 +4,8 @@ import com.gatherly.gatherly_api.dto.CreateEventRequest;
 import com.gatherly.gatherly_api.dto.EventListItemResponse;
 import com.gatherly.gatherly_api.dto.EventListResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
+import com.gatherly.gatherly_api.dto.OrganizerEventItemResponse;
+import com.gatherly.gatherly_api.dto.OrganizerEventListResponse;
 import com.gatherly.gatherly_api.model.AdmissionType;
 import com.gatherly.gatherly_api.model.Category;
 import com.gatherly.gatherly_api.model.Event;
@@ -28,6 +30,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -47,14 +50,15 @@ import java.util.stream.Collectors;
  * a meeting link and an address.” That keeps controllers thin and makes the same logic
  * reusable if you add another entry point later (for example a CLI or batch job).
  * <p>
- * Today this class only implements {@link #createEvent}; list/detail/update endpoints
- * can call into here as you add them.
+ * Implements create, public list/detail reads, and the organizer dashboard list.
  */
 @Service
 public class EventService {
     private static final int DEFAULT_PAGE = 0;
     private static final int DEFAULT_SIZE = 25;
     private static final int MAX_PAGE_SIZE = 100;
+    /** Soft-deleted events remain visible to the organizer until this many days after {@code deleted_at}. */
+    private static final int SOFT_DELETE_GRACE_DAYS = 7;
 
     /** Looks up the organizer’s {@link Profile} row (the user id from the JWT). */
     private final ProfileRepository profileRepository;
@@ -152,6 +156,50 @@ public class EventService {
                 .toList();
 
         return new EventListResponse(
+                content,
+                eventsPage.getNumber(),
+                eventsPage.getSize(),
+                eventsPage.getTotalElements(),
+                eventsPage.getTotalPages()
+        );
+    }
+
+    /**
+     * Paginated dashboard for the organizer: all non-purged lifecycle states, with optional status filter.
+     * Soft-deleted rows outside the grace window are excluded at query time.
+     */
+    @Transactional(readOnly = true)
+    public OrganizerEventListResponse getMyEvents(UUID organizerId, EventStatus statusFilter, int page, int size) {
+        int normalizedPage = Math.max(page, DEFAULT_PAGE);
+        int normalizedSize = normalizeSize(size);
+        PageRequest pageable = PageRequest.of(normalizedPage, normalizedSize);
+        OffsetDateTime graceCutoff = OffsetDateTime.now(ZoneOffset.UTC).minusDays(SOFT_DELETE_GRACE_DAYS);
+
+        Page<Event> eventsPage = statusFilter == null
+                ? eventRepository.findOrganizerDashboardEventsAll(
+                        organizerId,
+                        graceCutoff,
+                        EventStatus.soft_deleted,
+                        pageable
+                )
+                : eventRepository.findOrganizerDashboardEventsFiltered(
+                        organizerId,
+                        graceCutoff,
+                        EventStatus.soft_deleted,
+                        statusFilter,
+                        pageable
+                );
+        List<Event> events = eventsPage.getContent();
+        Map<UUID, List<String>> categoriesByEventId = loadCategoryNamesByEventId(events);
+
+        List<OrganizerEventItemResponse> content = events.stream()
+                .map(event -> OrganizerEventItemResponse.from(
+                        event,
+                        categoriesByEventId.getOrDefault(event.getId(), List.of())
+                ))
+                .toList();
+
+        return new OrganizerEventListResponse(
                 content,
                 eventsPage.getNumber(),
                 eventsPage.getSize(),

--- a/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
@@ -7,6 +7,10 @@ import com.gatherly.gatherly_api.dto.EventListItemResponse;
 import com.gatherly.gatherly_api.dto.EventListResponse;
 import com.gatherly.gatherly_api.dto.EventOrganizerResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
+import com.gatherly.gatherly_api.dto.OrganizerEventItemResponse;
+import com.gatherly.gatherly_api.dto.OrganizerEventListResponse;
+import com.gatherly.gatherly_api.exception.GlobalExceptionHandler;
+import com.gatherly.gatherly_api.model.EventStatus;
 import com.gatherly.gatherly_api.service.EventService;
 
 import org.junit.jupiter.api.Test;
@@ -34,7 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(EventController.class)
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, GlobalExceptionHandler.class})
 class EventControllerTest {
 
     private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
@@ -136,6 +140,45 @@ class EventControllerTest {
                             new EventOrganizerResponse(USER_ID, "Jane Doe")
                     );
                 }
+
+                @Override
+                public OrganizerEventListResponse getMyEvents(
+                        UUID organizerId,
+                        EventStatus statusFilter,
+                        int page,
+                        int size
+                ) {
+                    return new OrganizerEventListResponse(
+                            List.of(new OrganizerEventItemResponse(
+                                    EVENT_ID,
+                                    "My Dashboard Event",
+                                    "<p>D</p>",
+                                    "in_person",
+                                    "free",
+                                    null,
+                                    null,
+                                    OffsetDateTime.parse("2026-04-01T18:00:00Z"),
+                                    OffsetDateTime.parse("2026-04-01T21:00:00Z"),
+                                    "America/Toronto",
+                                    new EventAddressResponse("1 St", null, "Toronto", "ON", "M5V 1A1"),
+                                    null,
+                                    0,
+                                    50,
+                                    false,
+                                    List.of("Tech"),
+                                    EventStatus.active.name(),
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    new EventOrganizerResponse(USER_ID, "Jane Doe")
+                            )),
+                            page,
+                            size,
+                            1,
+                            1
+                    );
+                }
             };
         }
 
@@ -217,6 +260,44 @@ class EventControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.page").value(2))
                 .andExpect(jsonPath("$.size").value(10));
+    }
+
+    @Test
+    void getMyEvents_withoutToken_returns401() throws Exception {
+        mockMvc.perform(get("/api/events/my"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getMyEvents_withValidToken_returns200() throws Exception {
+        mockMvc.perform(get("/api/events/my")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(EVENT_ID.toString()))
+                .andExpect(jsonPath("$.content[0].title").value("My Dashboard Event"))
+                .andExpect(jsonPath("$.content[0].status").value("active"))
+                .andExpect(jsonPath("$.content[0].organizer.id").value(USER_ID.toString()))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    void getMyEvents_withStatusQuery_returns200() throws Exception {
+        mockMvc.perform(get("/api/events/my?status=flagged&page=1&size=10")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page").value(1))
+                .andExpect(jsonPath("$.size").value(10));
+    }
+
+    @Test
+    void getMyEvents_invalidStatus_returns400Json() throws Exception {
+        mockMvc.perform(get("/api/events/my?status=not_a_status")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("Invalid status filter."));
     }
 
     @Test

--- a/src/test/java/com/gatherly/gatherly_api/service/EventServiceTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/service/EventServiceTest.java
@@ -3,6 +3,7 @@ package com.gatherly.gatherly_api.service;
 import com.gatherly.gatherly_api.dto.CreateEventRequest;
 import com.gatherly.gatherly_api.dto.EventListResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
+import com.gatherly.gatherly_api.dto.OrganizerEventListResponse;
 import com.gatherly.gatherly_api.model.AdmissionType;
 import com.gatherly.gatherly_api.model.Category;
 import com.gatherly.gatherly_api.model.Event;
@@ -28,18 +29,23 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -423,6 +429,74 @@ class EventServiceTest {
         assertEquals(0, response.totalElements());
         assertEquals(0, response.totalPages());
         verify(eventCategoryRepository, never()).findByEvent_IdIn(anyList());
+    }
+
+    @Test
+    void getMyEvents_returnsMappedPageAndCallsRepository() {
+        Event e = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+        when(eventRepository.findOrganizerDashboardEventsAll(
+                eq(ORGANIZER_ID),
+                any(OffsetDateTime.class),
+                eq(EventStatus.soft_deleted),
+                any(PageRequest.class)
+        )).thenReturn(new PageImpl<>(List.of(e), PageRequest.of(0, 25), 1));
+        when(eventCategoryRepository.findByEvent_IdIn(List.of(e.getId()))).thenReturn(List.of());
+
+        OrganizerEventListResponse response = eventService.getMyEvents(ORGANIZER_ID, null, 0, 25);
+
+        assertEquals(1, response.content().size());
+        assertEquals("Mine", response.content().get(0).title());
+        assertEquals("active", response.content().get(0).status());
+        assertEquals(ORGANIZER_ID, response.content().get(0).organizer().id());
+        assertEquals(1, response.totalElements());
+    }
+
+    @Test
+    void getMyEvents_passesStatusFilterToRepository() {
+        when(eventRepository.findOrganizerDashboardEventsFiltered(
+                eq(ORGANIZER_ID),
+                any(OffsetDateTime.class),
+                eq(EventStatus.soft_deleted),
+                eq(EventStatus.flagged),
+                any(PageRequest.class)
+        )).thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 25), 0));
+
+        OrganizerEventListResponse response = eventService.getMyEvents(ORGANIZER_ID, EventStatus.flagged, 0, 25);
+
+        assertEquals(0, response.content().size());
+        verify(eventRepository).findOrganizerDashboardEventsFiltered(
+                eq(ORGANIZER_ID),
+                any(OffsetDateTime.class),
+                eq(EventStatus.soft_deleted),
+                eq(EventStatus.flagged),
+                any(Pageable.class)
+        );
+    }
+
+    @Test
+    void getMyEvents_usesGraceCutoffSevenDaysAgoUtc() {
+        when(eventRepository.findOrganizerDashboardEventsAll(
+                eq(ORGANIZER_ID),
+                any(OffsetDateTime.class),
+                eq(EventStatus.soft_deleted),
+                any(PageRequest.class)
+        )).thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 25), 0));
+
+        eventService.getMyEvents(ORGANIZER_ID, null, 0, 25);
+
+        ArgumentCaptor<OffsetDateTime> graceCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+        verify(eventRepository).findOrganizerDashboardEventsAll(
+                eq(ORGANIZER_ID),
+                graceCaptor.capture(),
+                eq(EventStatus.soft_deleted),
+                any(Pageable.class)
+        );
+        OffsetDateTime expected = OffsetDateTime.now(ZoneOffset.UTC).minusDays(7);
+        long deltaSeconds = Math.abs(ChronoUnit.SECONDS.between(graceCaptor.getValue(), expected));
+        assertTrue(deltaSeconds <= 3L);
     }
 
     @Test


### PR DESCRIPTION
This commit introduces a new GET endpoint `/api/events/my` that allows authenticated users to retrieve a paginated list of events they have created, including all lifecycle states (active, archived, flagged, and soft-deleted within a 7-day grace period). The response structure is enhanced with detailed event information, including status and flag metadata. The `EventService` is updated to handle the new functionality, and corresponding DTOs are added for the response format. Unit tests are included to validate the endpoint's behavior and ensure proper access control and filtering by status.

Closes #46 