### PR TITLE
Implement event update, soft delete, and restore functionality

### DIFF
--- a/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
+++ b/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
@@ -3,6 +3,7 @@ package com.gatherly.gatherly_api.controller;
 import com.gatherly.gatherly_api.dto.CreateEventRequest;
 import com.gatherly.gatherly_api.dto.EventListResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
+import com.gatherly.gatherly_api.dto.UpdateEventRequest;
 import com.gatherly.gatherly_api.dto.OrganizerEventListResponse;
 import com.gatherly.gatherly_api.model.EventStatus;
 import com.gatherly.gatherly_api.service.EventService;
@@ -24,9 +25,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -228,6 +232,88 @@ public class EventController {
         UUID organizerId = readUserIdFromJwt(jwt);
         EventResponse body = eventService.createEvent(organizerId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(body);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(
+            summary = "Update an event",
+            description = "Updates mutable fields for an event you own. "
+                    + "Admission and event type cannot change. "
+                    + "maxCapacity cannot decrease.",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Event updated.",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = EventResponse.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "400", description = "Validation failed or event is soft deleted."),
+                    @ApiResponse(responseCode = "401", description = "Missing or invalid token."),
+                    @ApiResponse(responseCode = "403", description = "Authenticated user is not the organizer."),
+                    @ApiResponse(responseCode = "404", description = "Event not found."),
+                    @ApiResponse(responseCode = "409", description = "maxCapacity would decrease.")
+            }
+    )
+    public ResponseEntity<EventResponse> updateEvent(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable UUID id,
+            @Valid @RequestBody UpdateEventRequest request
+    ) {
+        UUID organizerId = readUserIdFromJwt(jwt);
+        return ResponseEntity.ok(eventService.updateEvent(organizerId, id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(
+            summary = "Soft delete an event",
+            description = "Sets the event to soft_deleted and records deleted_at. Only the organizer may delete.",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Soft deleted (or already deleted)."),
+                    @ApiResponse(responseCode = "401", description = "Missing or invalid token."),
+                    @ApiResponse(responseCode = "403", description = "Authenticated user is not the organizer."),
+                    @ApiResponse(responseCode = "404", description = "Event not found.")
+            }
+    )
+    public ResponseEntity<Void> softDeleteEvent(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable UUID id
+    ) {
+        UUID organizerId = readUserIdFromJwt(jwt);
+        eventService.softDeleteEvent(organizerId, id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{id}/restore")
+    @Operation(
+            summary = "Restore a soft deleted event",
+            description = "Within the 7-day grace window, clears soft delete and sets status to active or archived "
+                    + "based on whether end time has passed.",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Event restored.",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = EventResponse.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "400", description = "Event is not soft deleted."),
+                    @ApiResponse(responseCode = "401", description = "Missing or invalid token."),
+                    @ApiResponse(responseCode = "403", description = "Authenticated user is not the organizer."),
+                    @ApiResponse(responseCode = "404", description = "Event not found or grace period expired.")
+            }
+    )
+    public ResponseEntity<EventResponse> restoreEvent(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable UUID id
+    ) {
+        UUID organizerId = readUserIdFromJwt(jwt);
+        return ResponseEntity.ok(eventService.restoreEvent(organizerId, id));
     }
 
     /**

--- a/src/main/java/com/gatherly/gatherly_api/dto/UpdateEventRequest.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/UpdateEventRequest.java
@@ -1,0 +1,37 @@
+package com.gatherly.gatherly_api.dto;
+
+import com.gatherly.gatherly_api.model.Province;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Request body for {@code PUT /events/{id}}.
+ * <p>
+ * Same mutable fields as {@link CreateEventRequest}, but without {@code eventType},
+ * {@code admissionType}, or {@code admissionFee} — those are fixed at creation (see database triggers).
+ * Cross-field rules (virtual needs a link, etc.) live in {@link com.gatherly.gatherly_api.service.EventService}.
+ */
+public record UpdateEventRequest(
+        @NotBlank @Size(max = 150) String title,
+        @NotBlank String description,
+        @NotNull OffsetDateTime startTime,
+        @NotNull OffsetDateTime endTime,
+        @NotBlank @Size(max = 50) String timezone,
+        @Size(max = 255) String addressLine1,
+        @Size(max = 255) String addressLine2,
+        @Size(max = 100) String city,
+        Province province,
+        @Size(max = 7) String postalCode,
+        String meetingLink,
+        String coverImageUrl,
+        @NotNull @Positive Integer maxCapacity,
+        @Size(max = 3) List<UUID> categoryIds
+) {
+}

--- a/src/main/java/com/gatherly/gatherly_api/model/Event.java
+++ b/src/main/java/com/gatherly/gatherly_api/model/Event.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -34,6 +35,7 @@ import java.util.UUID;
 @Entity
 @Table(name = "events")
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/gatherly/gatherly_api/repository/EventCategoryRepository.java
+++ b/src/main/java/com/gatherly/gatherly_api/repository/EventCategoryRepository.java
@@ -21,4 +21,9 @@ public interface EventCategoryRepository extends JpaRepository<EventCategory, UU
      * Loads category links for many events in one query to avoid N+1 selects on list pages.
      */
     List<EventCategory> findByEvent_IdIn(List<UUID> eventIds);
+
+    /**
+     * Removes all category links for an event before replacing them on update.
+     */
+    void deleteByEvent_Id(UUID eventId);
 }

--- a/src/main/java/com/gatherly/gatherly_api/service/EventService.java
+++ b/src/main/java/com/gatherly/gatherly_api/service/EventService.java
@@ -2,6 +2,7 @@ package com.gatherly.gatherly_api.service;
 
 import com.gatherly.gatherly_api.dto.CreateEventRequest;
 import com.gatherly.gatherly_api.dto.EventListItemResponse;
+import com.gatherly.gatherly_api.dto.UpdateEventRequest;
 import com.gatherly.gatherly_api.dto.EventListResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
 import com.gatherly.gatherly_api.dto.OrganizerEventItemResponse;
@@ -13,6 +14,7 @@ import com.gatherly.gatherly_api.model.EventCategory;
 import com.gatherly.gatherly_api.model.EventStatus;
 import com.gatherly.gatherly_api.model.EventType;
 import com.gatherly.gatherly_api.model.Profile;
+import com.gatherly.gatherly_api.model.Province;
 import com.gatherly.gatherly_api.repository.CategoryRepository;
 import com.gatherly.gatherly_api.repository.EventCategoryRepository;
 import com.gatherly.gatherly_api.repository.EventRepository;
@@ -50,7 +52,7 @@ import java.util.stream.Collectors;
  * a meeting link and an address.” That keeps controllers thin and makes the same logic
  * reusable if you add another entry point later (for example a CLI or batch job).
  * <p>
- * Implements create, public list/detail reads, and the organizer dashboard list.
+ * Implements create, update, soft delete, restore, public list/detail reads, and the organizer dashboard list.
  */
 @Service
 public class EventService {
@@ -130,6 +132,165 @@ public class EventService {
 
         List<String> categoryNames = categories.stream().map(Category::getName).toList();
         return EventResponse.from(saved, categoryNames);
+    }
+
+    /**
+     * Updates an event owned by {@code organizerId}. Immutable columns ({@code event_type}, admission, fee)
+     * stay on the entity; the request only carries fields the API allows to change.
+     * <p>
+     * Order of operations: authorize → reject soft-deleted edits → validate body → write scalar columns →
+     * replace junction rows → flush → refresh so {@code rsvp_count} and timestamps match Postgres.
+     */
+    @Transactional
+    public EventResponse updateEvent(UUID organizerId, UUID eventId, UpdateEventRequest request) {
+        Event event = loadEventForOrganizer(eventId, organizerId);
+        if (event.getStatus() == EventStatus.soft_deleted) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Cannot update a soft-deleted event. Restore it first."
+            );
+        }
+        if (request.maxCapacity() < event.getMaxCapacity()) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "maxCapacity cannot be decreased after event creation."
+            );
+        }
+
+        validateUpdateRequest(request, event.getEventType());
+
+        applyUpdateToEvent(event, request);
+
+        // Replace categories: delete old links first so we never exceed the unique constraint briefly.
+        eventCategoryRepository.deleteByEvent_Id(eventId);
+        eventRepository.flush();
+
+        List<UUID> categoryIds = request.categoryIds() == null ? List.of() : request.categoryIds();
+        List<Category> categories = loadCategoriesInOrder(categoryIds);
+        if (!categories.isEmpty()) {
+            List<EventCategory> links = new ArrayList<>();
+            for (Category category : categories) {
+                links.add(EventCategory.builder()
+                        .event(event)
+                        .category(category)
+                        .build());
+            }
+            eventCategoryRepository.saveAll(links);
+        }
+
+        eventRepository.save(event);
+        eventRepository.flush();
+        entityManager.refresh(event);
+
+        List<String> categoryNames = categories.stream().map(Category::getName).toList();
+        return EventResponse.from(event, categoryNames);
+    }
+
+    /**
+     * Soft-deletes an event: sets status and {@code deleted_at}. Idempotent if already deleted.
+     */
+    @Transactional
+    public void softDeleteEvent(UUID organizerId, UUID eventId) {
+        Event event = loadEventForOrganizer(eventId, organizerId);
+        if (event.getStatus() == EventStatus.soft_deleted) {
+            return;
+        }
+        event.setStatus(EventStatus.soft_deleted);
+        event.setDeletedAt(OffsetDateTime.now(ZoneOffset.UTC));
+        eventRepository.save(event);
+    }
+
+    /**
+     * Undoes a soft delete within the grace window. Computes {@code active} vs {@code archived} from
+     * {@code end_time} vs “now” (UTC). Clears flag columns so the row’s {@link EventStatus} matches the
+     * documented response (no {@code flagged} after restore).
+     */
+    @Transactional
+    public EventResponse restoreEvent(UUID organizerId, UUID eventId) {
+        Event event = loadEventForOrganizer(eventId, organizerId);
+        if (event.getStatus() != EventStatus.soft_deleted) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Event is not in a soft deleted state."
+            );
+        }
+        OffsetDateTime deletedAt = event.getDeletedAt();
+        if (deletedAt == null) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Event is not in a soft deleted state."
+            );
+        }
+        OffsetDateTime graceCutoff = OffsetDateTime.now(ZoneOffset.UTC).minusDays(SOFT_DELETE_GRACE_DAYS);
+        if (deletedAt.isBefore(graceCutoff)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found.");
+        }
+
+        event.setDeletedAt(null);
+        event.setFlagReason(null);
+        event.setFlaggedBy(null);
+        event.setFlaggedAt(null);
+
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        if (event.getEndTime().isAfter(now)) {
+            event.setStatus(EventStatus.active);
+        } else {
+            event.setStatus(EventStatus.archived);
+        }
+
+        eventRepository.save(event);
+        eventRepository.flush();
+        entityManager.refresh(event);
+
+        List<String> categoryNames = eventCategoryRepository.findByEvent_Id(eventId).stream()
+                .filter(link -> link.getCategory() != null && link.getCategory().getName() != null)
+                .sorted(Comparator.comparing(EventCategory::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .map(link -> link.getCategory().getName())
+                .toList();
+
+        return EventResponse.from(event, categoryNames);
+    }
+
+    /**
+     * Loads the row and enforces “this JWT user owns the event”: missing id → 404, wrong organizer → 403.
+     */
+    private Event loadEventForOrganizer(UUID eventId, UUID organizerId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found."));
+        if (event.getOrganizer() == null || !event.getOrganizer().getId().equals(organizerId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You are not the organizer of this event.");
+        }
+        return event;
+    }
+
+    private static void applyUpdateToEvent(Event event, UpdateEventRequest request) {
+        event.setTitle(request.title().trim());
+        event.setDescription(request.description().trim());
+        event.setCoverImageUrl(blankToNull(request.coverImageUrl()));
+        event.setMeetingLink(blankToNull(request.meetingLink()));
+        event.setAddressLine1(blankToNull(request.addressLine1()));
+        event.setAddressLine2(blankToNull(request.addressLine2()));
+        event.setCity(blankToNull(request.city()));
+        event.setProvince(request.province());
+        event.setPostalCode(blankToNull(request.postalCode()));
+        event.setTimezone(request.timezone().trim());
+        event.setStartTime(request.startTime());
+        event.setEndTime(request.endTime());
+        event.setMaxCapacity(request.maxCapacity());
+    }
+
+    private void validateUpdateRequest(UpdateEventRequest request, EventType eventType) {
+        validateTimeOrder(request.startTime(), request.endTime());
+        validateCategoryIdList(request.categoryIds());
+        validateEventTypeFields(
+                eventType,
+                request.meetingLink(),
+                request.addressLine1(),
+                request.city(),
+                request.province(),
+                request.postalCode()
+        );
+        validateOptionalUrlStrings(request.meetingLink(), request.coverImageUrl());
     }
 
     /**
@@ -296,32 +457,43 @@ public class EventService {
      * on {@link CreateEventRequest} (for example “end must be after start”).
      */
     private void validateCreateRequest(CreateEventRequest request) {
-        OffsetDateTime start = request.startTime();
-        OffsetDateTime end = request.endTime();
+        validateTimeOrder(request.startTime(), request.endTime());
+        validateCategoryIdList(request.categoryIds());
+        validateAdmissionRules(request);
+        validateEventTypeFields(
+                request.eventType(),
+                request.meetingLink(),
+                request.addressLine1(),
+                request.city(),
+                request.province(),
+                request.postalCode()
+        );
+        validateOptionalUrlStrings(request.meetingLink(), request.coverImageUrl());
+    }
+
+    private static void validateTimeOrder(OffsetDateTime start, OffsetDateTime end) {
         if (!end.isAfter(start)) {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "endTime must be after startTime."
             );
         }
+    }
 
-        List<UUID> categoryIds = request.categoryIds() == null ? List.of() : request.categoryIds();
-        if (categoryIds.size() > 3) {
+    private static void validateCategoryIdList(List<UUID> categoryIds) {
+        List<UUID> ids = categoryIds == null ? List.of() : categoryIds;
+        if (ids.size() > 3) {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "At most three categories are allowed."
             );
         }
-        if (categoryIds.size() != new HashSet<>(categoryIds).size()) {
+        if (ids.size() != new HashSet<>(ids).size()) {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "Duplicate category ids are not allowed."
             );
         }
-
-        validateAdmissionRules(request);
-        validateEventTypeRules(request);
-        validateOptionalUrls(request);
     }
 
     /** Ensures free vs paid rules line up with {@code admission_fee} in the schema. */
@@ -348,12 +520,18 @@ public class EventService {
      * Virtual/hybrid need a link; in-person/hybrid need a Canadian address block.
      * These rules mirror {@code docs/api_endpoints.md} and the database check constraints.
      */
-    private static void validateEventTypeRules(CreateEventRequest request) {
-        EventType type = request.eventType();
+    private static void validateEventTypeFields(
+            EventType type,
+            String meetingLink,
+            String addressLine1,
+            String city,
+            Province province,
+            String postalCode
+    ) {
         boolean needLink = type == EventType.virtual || type == EventType.hybrid;
         boolean needAddress = type == EventType.in_person || type == EventType.hybrid;
 
-        if (needLink && isBlank(request.meetingLink())) {
+        if (needLink && isBlank(meetingLink)) {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "meetingLink is required for virtual and hybrid events."
@@ -361,10 +539,10 @@ public class EventService {
         }
 
         if (needAddress) {
-            if (isBlank(request.addressLine1())
-                    || isBlank(request.city())
-                    || request.province() == null
-                    || isBlank(request.postalCode())) {
+            if (isBlank(addressLine1)
+                    || isBlank(city)
+                    || province == null
+                    || isBlank(postalCode)) {
                 throw new ResponseStatusException(
                         HttpStatus.BAD_REQUEST,
                         "addressLine1, city, province, and postalCode are required for in-person and hybrid events."
@@ -374,12 +552,12 @@ public class EventService {
     }
 
     /** When present, meeting and cover URLs must be real http(s) URLs with a host. */
-    private static void validateOptionalUrls(CreateEventRequest request) {
-        if (!isBlank(request.meetingLink())) {
-            requireHttpOrHttpsUrl("meetingLink", request.meetingLink().trim());
+    private static void validateOptionalUrlStrings(String meetingLink, String coverImageUrl) {
+        if (!isBlank(meetingLink)) {
+            requireHttpOrHttpsUrl("meetingLink", meetingLink.trim());
         }
-        if (!isBlank(request.coverImageUrl())) {
-            requireHttpOrHttpsUrl("coverImageUrl", request.coverImageUrl().trim());
+        if (!isBlank(coverImageUrl)) {
+            requireHttpOrHttpsUrl("coverImageUrl", coverImageUrl.trim());
         }
     }
 

--- a/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
@@ -9,6 +9,7 @@ import com.gatherly.gatherly_api.dto.EventOrganizerResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
 import com.gatherly.gatherly_api.dto.OrganizerEventItemResponse;
 import com.gatherly.gatherly_api.dto.OrganizerEventListResponse;
+import com.gatherly.gatherly_api.dto.UpdateEventRequest;
 import com.gatherly.gatherly_api.exception.GlobalExceptionHandler;
 import com.gatherly.gatherly_api.model.EventStatus;
 import com.gatherly.gatherly_api.service.EventService;
@@ -20,6 +21,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -31,8 +33,11 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -177,6 +182,76 @@ class EventControllerTest {
                             size,
                             1,
                             1
+                    );
+                }
+
+                @Override
+                public EventResponse updateEvent(UUID organizerId, UUID eventId, UpdateEventRequest request) {
+                    if ("not-owner".equals(request.title())) {
+                        throw new ResponseStatusException(
+                                HttpStatus.FORBIDDEN,
+                                "You are not the organizer of this event."
+                        );
+                    }
+                    return new EventResponse(
+                            eventId,
+                            request.title(),
+                            request.description(),
+                            "in_person",
+                            "free",
+                            null,
+                            request.startTime(),
+                            request.endTime(),
+                            request.timezone(),
+                            new EventAddressResponse(
+                                    request.addressLine1(),
+                                    request.addressLine2(),
+                                    request.city(),
+                                    request.province() == null ? null : request.province().name(),
+                                    request.postalCode()
+                            ),
+                            request.coverImageUrl(),
+                            0,
+                            request.maxCapacity(),
+                            false,
+                            List.of(),
+                            new EventOrganizerResponse(USER_ID, "Jane Doe")
+                    );
+                }
+
+                @Override
+                public void softDeleteEvent(UUID organizerId, UUID eventId) {
+                    if (!EVENT_ID.equals(eventId)) {
+                        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found.");
+                    }
+                }
+
+                @Override
+                public EventResponse restoreEvent(UUID organizerId, UUID eventId) {
+                    UUID notSoftDeleted = UUID.fromString("00000000-0000-0000-0000-0000000000ee");
+                    if (notSoftDeleted.equals(eventId)) {
+                        throw new ResponseStatusException(
+                                HttpStatus.BAD_REQUEST,
+                                "Event is not in a soft deleted state."
+                        );
+                    }
+                    return new EventResponse(
+                            eventId,
+                            "Restored",
+                            "<p>R</p>",
+                            "in_person",
+                            "free",
+                            null,
+                            OffsetDateTime.parse("2026-04-01T18:00:00Z"),
+                            OffsetDateTime.parse("2026-04-01T21:00:00Z"),
+                            "America/Toronto",
+                            new EventAddressResponse("1 St", null, "Toronto", "ON", "M5V 1A1"),
+                            null,
+                            0,
+                            50,
+                            false,
+                            List.of(),
+                            new EventOrganizerResponse(USER_ID, "Jane Doe")
                     );
                 }
             };
@@ -455,5 +530,118 @@ class EventControllerTest {
                 .andExpect(jsonPath("$.error").value("Bad Request"))
                 .andExpect(jsonPath("$.message").value("meetingLink is required for virtual and hybrid events."))
                 .andExpect(jsonPath("$.path").value("/api/events"));
+    }
+
+    @Test
+    void putEvent_withoutToken_returns401() throws Exception {
+        String body = """
+                {
+                  "title": "T",
+                  "description": "<p>D</p>",
+                  "startTime": "2026-04-01T18:00:00Z",
+                  "endTime": "2026-04-01T21:00:00Z",
+                  "timezone": "America/Toronto",
+                  "addressLine1": "1 St",
+                  "city": "Toronto",
+                  "province": "ON",
+                  "postalCode": "M5V 1A1",
+                  "maxCapacity": 50,
+                  "categoryIds": []
+                }
+                """;
+        mockMvc.perform(put("/api/events/" + EVENT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void putEvent_withValidToken_returns200() throws Exception {
+        String body = """
+                {
+                  "title": "Updated",
+                  "description": "<p>D</p>",
+                  "startTime": "2026-04-01T18:00:00Z",
+                  "endTime": "2026-04-01T21:00:00Z",
+                  "timezone": "America/Toronto",
+                  "addressLine1": "1 St",
+                  "city": "Toronto",
+                  "province": "ON",
+                  "postalCode": "M5V 1A1",
+                  "maxCapacity": 50,
+                  "categoryIds": []
+                }
+                """;
+        mockMvc.perform(put("/api/events/" + EVENT_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Updated"))
+                .andExpect(jsonPath("$.organizer.id").value(USER_ID.toString()));
+    }
+
+    @Test
+    void putEvent_forbidden_returns403Json() throws Exception {
+        String body = """
+                {
+                  "title": "not-owner",
+                  "description": "<p>D</p>",
+                  "startTime": "2026-04-01T18:00:00Z",
+                  "endTime": "2026-04-01T21:00:00Z",
+                  "timezone": "America/Toronto",
+                  "addressLine1": "1 St",
+                  "city": "Toronto",
+                  "province": "ON",
+                  "postalCode": "M5V 1A1",
+                  "maxCapacity": 50,
+                  "categoryIds": []
+                }
+                """;
+        mockMvc.perform(put("/api/events/" + EVENT_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.message").value("You are not the organizer of this event."));
+    }
+
+    @Test
+    void deleteEvent_withoutToken_returns401() throws Exception {
+        mockMvc.perform(delete("/api/events/" + EVENT_ID))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void deleteEvent_withValidToken_returns204() throws Exception {
+        mockMvc.perform(delete("/api/events/" + EVENT_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void patchRestoreEvent_withoutToken_returns401() throws Exception {
+        mockMvc.perform(patch("/api/events/" + EVENT_ID + "/restore"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void patchRestoreEvent_withValidToken_returns200() throws Exception {
+        mockMvc.perform(patch("/api/events/" + EVENT_ID + "/restore")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Restored"));
+    }
+
+    @Test
+    void patchRestoreEvent_notSoftDeleted_returns400Json() throws Exception {
+        UUID id = UUID.fromString("00000000-0000-0000-0000-0000000000ee");
+        mockMvc.perform(patch("/api/events/" + id + "/restore")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Event is not in a soft deleted state."));
     }
 }

--- a/src/test/java/com/gatherly/gatherly_api/service/EventServiceTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/service/EventServiceTest.java
@@ -3,6 +3,7 @@ package com.gatherly.gatherly_api.service;
 import com.gatherly.gatherly_api.dto.CreateEventRequest;
 import com.gatherly.gatherly_api.dto.EventListResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
+import com.gatherly.gatherly_api.dto.UpdateEventRequest;
 import com.gatherly.gatherly_api.dto.OrganizerEventListResponse;
 import com.gatherly.gatherly_api.model.AdmissionType;
 import com.gatherly.gatherly_api.model.Category;
@@ -41,6 +42,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -51,6 +54,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @ExtendWith(MockitoExtension.class)
@@ -553,6 +558,207 @@ class EventServiceTest {
         assertEquals(NOT_FOUND, ex.getStatusCode());
     }
 
+    @Test
+    void updateEvent_whenEventMissing_throws404() {
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> eventService.updateEvent(ORGANIZER_ID, SAVED_EVENT_ID, validUpdateRequest())
+        );
+        assertEquals(NOT_FOUND, ex.getStatusCode());
+    }
+
+    @Test
+    void updateEvent_whenNotOrganizer_throws403() {
+        UUID otherId = UUID.fromString("00000000-0000-0000-0000-000000000099");
+        Profile otherOrganizer = Profile.builder()
+                .id(otherId)
+                .fullName("Other")
+                .email("other@example.com")
+                .role(Role.user)
+                .avatarUrl(null)
+                .addressLine1(null)
+                .addressLine2(null)
+                .city(null)
+                .province(null)
+                .postalCode(null)
+                .createdAt(OffsetDateTime.parse("2026-01-01T00:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-01-01T00:00:00Z"))
+                .build();
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                otherOrganizer
+        );
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> eventService.updateEvent(ORGANIZER_ID, SAVED_EVENT_ID, validUpdateRequest())
+        );
+        assertEquals(FORBIDDEN, ex.getStatusCode());
+    }
+
+    @Test
+    void updateEvent_whenSoftDeleted_throws400() {
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+        event.setStatus(EventStatus.soft_deleted);
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> eventService.updateEvent(ORGANIZER_ID, SAVED_EVENT_ID, validUpdateRequest())
+        );
+        assertEquals(BAD_REQUEST, ex.getStatusCode());
+    }
+
+    @Test
+    void updateEvent_whenMaxCapacityDecreases_throws409() {
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+
+        UpdateEventRequest req = new UpdateEventRequest(
+                "T",
+                "<p>D</p>",
+                OffsetDateTime.parse("2026-04-01T18:00:00Z"),
+                OffsetDateTime.parse("2026-04-01T21:00:00Z"),
+                "America/Toronto",
+                "123 Main St",
+                null,
+                "Toronto",
+                Province.ON,
+                "M5V 1A1",
+                null,
+                null,
+                40,
+                List.of()
+        );
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> eventService.updateEvent(ORGANIZER_ID, SAVED_EVENT_ID, req)
+        );
+        assertEquals(CONFLICT, ex.getStatusCode());
+    }
+
+    @Test
+    void updateEvent_happyPath_replacesCategoriesAndRefreshes() {
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+        doNothing().when(eventCategoryRepository).deleteByEvent_Id(SAVED_EVENT_ID);
+        when(eventRepository.save(any(Event.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        doNothing().when(entityManager).refresh(any(Event.class));
+
+        EventResponse response = eventService.updateEvent(ORGANIZER_ID, SAVED_EVENT_ID, validUpdateRequest());
+
+        assertEquals("Updated Title", response.title());
+        verify(eventCategoryRepository).deleteByEvent_Id(SAVED_EVENT_ID);
+        verify(entityManager).refresh(any(Event.class));
+    }
+
+    @Test
+    void softDeleteEvent_setsStatusAndDeletedAt() {
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+        when(eventRepository.save(any(Event.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        eventService.softDeleteEvent(ORGANIZER_ID, SAVED_EVENT_ID);
+
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+        verify(eventRepository).save(captor.capture());
+        assertEquals(EventStatus.soft_deleted, captor.getValue().getStatus());
+        assertNotNull(captor.getValue().getDeletedAt());
+    }
+
+    @Test
+    void restoreEvent_whenNotSoftDeleted_throws400() {
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> eventService.restoreEvent(ORGANIZER_ID, SAVED_EVENT_ID)
+        );
+        assertEquals(BAD_REQUEST, ex.getStatusCode());
+    }
+
+    @Test
+    void restoreEvent_whenGraceExpired_throws404() {
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+        event.setStatus(EventStatus.soft_deleted);
+        event.setDeletedAt(OffsetDateTime.now(ZoneOffset.UTC).minusDays(8));
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> eventService.restoreEvent(ORGANIZER_ID, SAVED_EVENT_ID)
+        );
+        assertEquals(NOT_FOUND, ex.getStatusCode());
+    }
+
+    @Test
+    void restoreEvent_whenEndTimeInFuture_setsActive() {
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+        event.setStatus(EventStatus.soft_deleted);
+        event.setDeletedAt(OffsetDateTime.now(ZoneOffset.UTC).minusDays(1));
+        event.setStartTime(OffsetDateTime.now(ZoneOffset.UTC).plusDays(1));
+        event.setEndTime(OffsetDateTime.now(ZoneOffset.UTC).plusDays(2));
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+        when(eventRepository.save(any(Event.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        doNothing().when(entityManager).refresh(any(Event.class));
+        when(eventCategoryRepository.findByEvent_Id(SAVED_EVENT_ID)).thenReturn(List.of());
+
+        eventService.restoreEvent(ORGANIZER_ID, SAVED_EVENT_ID);
+
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+        verify(eventRepository).save(captor.capture());
+        assertEquals(EventStatus.active, captor.getValue().getStatus());
+        assertNull(captor.getValue().getDeletedAt());
+    }
+
+    @Test
+    void restoreEvent_whenEndTimeInPast_setsArchived() {
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+        event.setStatus(EventStatus.soft_deleted);
+        event.setDeletedAt(OffsetDateTime.now(ZoneOffset.UTC).minusDays(1));
+        event.setStartTime(OffsetDateTime.now(ZoneOffset.UTC).minusDays(10));
+        event.setEndTime(OffsetDateTime.now(ZoneOffset.UTC).minusDays(1));
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+        when(eventRepository.save(any(Event.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        doNothing().when(entityManager).refresh(any(Event.class));
+        when(eventCategoryRepository.findByEvent_Id(SAVED_EVENT_ID)).thenReturn(List.of());
+
+        eventService.restoreEvent(ORGANIZER_ID, SAVED_EVENT_ID);
+
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+        verify(eventRepository).save(captor.capture());
+        assertEquals(EventStatus.archived, captor.getValue().getStatus());
+    }
+
     private static CreateEventRequest validInPersonRequest(List<UUID> categoryIds) {
         return new CreateEventRequest(
                 "Spring Meetup",
@@ -572,6 +778,25 @@ class EventServiceTest {
                 null,
                 50,
                 categoryIds
+        );
+    }
+
+    private static UpdateEventRequest validUpdateRequest() {
+        return new UpdateEventRequest(
+                "Updated Title",
+                "<p>D</p>",
+                OffsetDateTime.parse("2026-04-01T18:00:00Z"),
+                OffsetDateTime.parse("2026-04-01T21:00:00Z"),
+                "America/Toronto",
+                "123 Main St",
+                null,
+                "Toronto",
+                Province.ON,
+                "M5V 1A1",
+                null,
+                null,
+                50,
+                List.of()
         );
     }
 


### PR DESCRIPTION
This commit introduces new endpoints in the `EventController` for updating, soft deleting, and restoring events. The `PUT /events/{id}` endpoint allows organizers to update mutable fields of their events, while the `DELETE /events/{id}` endpoint soft deletes an event, marking it as deleted without removing it from the database. Additionally, a `PATCH /events/{id}/restore` endpoint is added to restore soft-deleted events within a 7-day grace period. The `EventService` is updated to handle these operations, including validation rules for updates and soft deletes. A new `UpdateEventRequest` DTO is created to encapsulate the update request data. Unit tests are added to ensure the correct behavior of the new functionality and access control.

Closes #47
Closes #48
Closes #49