### PR TITLE
Add flagging functionality for events

### DIFF
--- a/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
+++ b/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
@@ -1,10 +1,13 @@
 package com.gatherly.gatherly_api.controller;
 
 import com.gatherly.gatherly_api.dto.CreateEventRequest;
+import com.gatherly.gatherly_api.dto.FlagEventRequest;
 import com.gatherly.gatherly_api.dto.EventListResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
 import com.gatherly.gatherly_api.dto.UpdateEventRequest;
 import com.gatherly.gatherly_api.dto.OrganizerEventListResponse;
+import com.gatherly.gatherly_api.dto.OrganizerEventItemResponse;
+import com.gatherly.gatherly_api.model.Role;
 import com.gatherly.gatherly_api.model.EventStatus;
 import com.gatherly.gatherly_api.service.EventService;
 
@@ -38,6 +41,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -314,6 +318,88 @@ public class EventController {
     ) {
         UUID organizerId = readUserIdFromJwt(jwt);
         return ResponseEntity.ok(eventService.restoreEvent(organizerId, id));
+    }
+
+    @PatchMapping("/{id}/flag")
+    @Operation(
+            summary = "Flag an event",
+            description = "Flags an event as inappropriate. Restricted to moderator/admin roles only.",
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Event flagged successfully.",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = OrganizerEventItemResponse.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "400", description = "Missing or invalid flag reason."),
+                    @ApiResponse(responseCode = "401", description = "Missing or invalid token."),
+                    @ApiResponse(responseCode = "403", description = "Authenticated user does not have moderator or admin role."),
+                    @ApiResponse(responseCode = "404", description = "Event not found."),
+                    @ApiResponse(responseCode = "409", description = "Event is already flagged.")
+            }
+    )
+    public ResponseEntity<OrganizerEventItemResponse> flagEvent(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable UUID id,
+            @RequestBody FlagEventRequest request
+    ) {
+        UUID actorId = readUserIdFromJwt(jwt);
+        Role actorRole = parseUserRoleFromJwt(jwt);
+        if (actorRole == null || (actorRole != Role.moderator && actorRole != Role.admin)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
+        return ResponseEntity.ok(eventService.flagEvent(actorId, actorRole, id, request == null ? null : request.reason()));
+    }
+
+    /**
+     * Reads the application role from the JWT.
+     *
+     * <p>We mimic {@code SecurityConfig} for consistency:
+     * check app_metadata.role → user_metadata.role → top-level role (excluding "authenticated"/"anon").
+     */
+    private static Role parseUserRoleFromJwt(Jwt jwt) {
+        if (jwt == null) {
+            return null;
+        }
+
+        Object appMetadataClaim = jwt.getClaim("app_metadata");
+        if (appMetadataClaim instanceof Map<?, ?> appMetadataMap) {
+            Object r = appMetadataMap.get("role");
+            if (r instanceof String s && !s.isBlank()) {
+                return toRole(s);
+            }
+        }
+
+        Object userMetadataClaim = jwt.getClaim("user_metadata");
+        if (userMetadataClaim instanceof Map<?, ?> userMetadataMap) {
+            Object r = userMetadataMap.get("role");
+            if (r instanceof String s && !s.isBlank()) {
+                return toRole(s);
+            }
+        }
+
+        String top = jwt.getClaimAsString("role");
+        if (top == null || top.isBlank()
+                || "authenticated".equalsIgnoreCase(top)
+                || "anon".equalsIgnoreCase(top)) {
+            return null;
+        }
+        return toRole(top);
+    }
+
+    private static Role toRole(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        String normalized = raw.trim().toLowerCase();
+        try {
+            return Role.valueOf(normalized);
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/com/gatherly/gatherly_api/dto/FlagEventRequest.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/FlagEventRequest.java
@@ -1,0 +1,13 @@
+package com.gatherly.gatherly_api.dto;
+
+/**
+ * Request body for {@code PATCH /api/events/{id}/flag}.
+ *
+ * <p>The value must be one of the database {@code flag_reason} enum labels:
+ * {@code off_topic}, {@code nsfw}, {@code spam}, {@code misleading}, {@code other}.
+ *
+ * <p>Authorization (moderator/admin) is enforced by the controller/service.
+ */
+public record FlagEventRequest(String reason) {
+}
+

--- a/src/main/java/com/gatherly/gatherly_api/service/EventService.java
+++ b/src/main/java/com/gatherly/gatherly_api/service/EventService.java
@@ -11,8 +11,10 @@ import com.gatherly.gatherly_api.model.AdmissionType;
 import com.gatherly.gatherly_api.model.Category;
 import com.gatherly.gatherly_api.model.Event;
 import com.gatherly.gatherly_api.model.EventCategory;
+import com.gatherly.gatherly_api.model.FlagReason;
 import com.gatherly.gatherly_api.model.EventStatus;
 import com.gatherly.gatherly_api.model.EventType;
+import com.gatherly.gatherly_api.model.Role;
 import com.gatherly.gatherly_api.model.Profile;
 import com.gatherly.gatherly_api.model.Province;
 import com.gatherly.gatherly_api.repository.CategoryRepository;
@@ -249,6 +251,90 @@ public class EventService {
                 .toList();
 
         return EventResponse.from(event, categoryNames);
+    }
+
+    /**
+     * Flags an event with a moderator/admin-provided reason.
+     * <p>
+     * Business rules:
+     * <ul>
+     *   <li>Only {@link Role#moderator} and {@link Role#admin} may flag.</li>
+     *   <li>Flag reason is mandatory and must match the DB {@code flag_reason} enum.</li>
+     *   <li>Soft-deleted events are rejected (can only be restored by the organizer).</li>
+     *   <li>Already-flagged events are rejected with a 409 Conflict.</li>
+     * </ul>
+     */
+    @Transactional
+    public OrganizerEventItemResponse flagEvent(
+            UUID actorId,
+            Role actorRole,
+            UUID eventId,
+            String reason
+    ) {
+        if (actorRole != Role.moderator && actorRole != Role.admin) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
+
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Event not found."
+                ));
+
+        if (event.getStatus() == EventStatus.soft_deleted) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Cannot flag a soft-deleted event."
+            );
+        }
+        if (event.getStatus() == EventStatus.flagged) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Event is already flagged."
+            );
+        }
+
+        FlagReason parsedReason = parseFlagReason(reason);
+
+        Profile flaggedBy = profileRepository.findById(actorId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Profile not found for authenticated user."
+                ));
+
+        event.setStatus(EventStatus.flagged);
+        event.setFlagReason(parsedReason);
+        event.setFlaggedBy(flaggedBy);
+        event.setFlaggedAt(OffsetDateTime.now(ZoneOffset.UTC));
+
+        eventRepository.save(event);
+        eventRepository.flush();
+        entityManager.refresh(event);
+
+        List<String> categoryNames = sortedCategoryNamesForEvent(
+                eventCategoryRepository.findByEvent_Id(eventId)
+        );
+
+        return OrganizerEventItemResponse.from(event, categoryNames);
+    }
+
+    private static FlagReason parseFlagReason(String rawReason) {
+        if (isBlank(rawReason)) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Missing or invalid flag reason."
+            );
+        }
+
+        String normalized = rawReason.trim().toLowerCase();
+        try {
+            return FlagReason.valueOf(normalized);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Missing or invalid flag reason."
+            );
+        }
     }
 
     /**

--- a/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
@@ -12,6 +12,7 @@ import com.gatherly.gatherly_api.dto.OrganizerEventListResponse;
 import com.gatherly.gatherly_api.dto.UpdateEventRequest;
 import com.gatherly.gatherly_api.exception.GlobalExceptionHandler;
 import com.gatherly.gatherly_api.model.EventStatus;
+import com.gatherly.gatherly_api.model.Role;
 import com.gatherly.gatherly_api.service.EventService;
 
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,9 @@ class EventControllerTest {
 
     private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
     private static final UUID EVENT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000bb");
+    private static final UUID EVENT_ID_NOT_FOUND = UUID.fromString("00000000-0000-0000-0000-0000000000cc");
+    private static final UUID EVENT_ID_ALREADY_FLAGGED = UUID.fromString("00000000-0000-0000-0000-0000000000dd");
+    private static final UUID EVENT_ID_SOFT_DELETED = UUID.fromString("00000000-0000-0000-0000-0000000000ee");
 
     @Autowired
     private MockMvc mockMvc;
@@ -254,6 +258,66 @@ class EventControllerTest {
                             new EventOrganizerResponse(USER_ID, "Jane Doe")
                     );
                 }
+
+                @Override
+                public OrganizerEventItemResponse flagEvent(
+                        UUID actorId,
+                        Role actorRole,
+                        UUID eventId,
+                        String reason
+                ) {
+                    if (EVENT_ID_NOT_FOUND.equals(eventId)) {
+                        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found.");
+                    }
+                    if (EVENT_ID_SOFT_DELETED.equals(eventId)) {
+                        throw new ResponseStatusException(
+                                HttpStatus.BAD_REQUEST,
+                                "Cannot flag a soft-deleted event."
+                        );
+                    }
+                    if (EVENT_ID_ALREADY_FLAGGED.equals(eventId)) {
+                        throw new ResponseStatusException(
+                                HttpStatus.CONFLICT,
+                                "Event is already flagged."
+                        );
+                    }
+
+                    String normalized = reason == null ? null : reason.trim().toLowerCase();
+                    boolean valid = normalized != null && List.of(
+                            "off_topic", "nsfw", "spam", "misleading", "other"
+                    ).contains(normalized);
+                    if (!valid) {
+                        throw new ResponseStatusException(
+                                HttpStatus.BAD_REQUEST,
+                                "Missing or invalid flag reason."
+                        );
+                    }
+
+                    return new OrganizerEventItemResponse(
+                            eventId,
+                            "Flagged Event",
+                            "<p>F</p>",
+                            "in_person",
+                            "free",
+                            null,
+                            null,
+                            OffsetDateTime.parse("2026-04-01T18:00:00Z"),
+                            OffsetDateTime.parse("2026-04-01T21:00:00Z"),
+                            "America/Toronto",
+                            new EventAddressResponse("1 St", null, "Toronto", "ON", "M5V 1A1"),
+                            null,
+                            0,
+                            50,
+                            false,
+                            List.of("Tech"),
+                            "flagged",
+                            normalized,
+                            OffsetDateTime.parse("2026-04-01T18:00:00Z"),
+                            new EventOrganizerResponse(actorId, "Jane Doe"),
+                            null,
+                            new EventOrganizerResponse(USER_ID, "Jane Doe")
+                    );
+                }
             };
         }
 
@@ -268,10 +332,14 @@ class EventControllerTest {
                 }
 
                 Instant now = Instant.now();
+                String role = switch (tokenValue) {
+                    case "moderator", "admin", "user" -> tokenValue;
+                    default -> "user";
+                };
                 return Jwt.withTokenValue(tokenValue)
                         .header("alg", "RS256")
                         .subject(USER_ID.toString())
-                        .claim("role", "user")
+                        .claim("role", role)
                         .issuedAt(now)
                         .expiresAt(now.plusSeconds(3600))
                         .build();
@@ -643,5 +711,121 @@ class EventControllerTest {
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("Event is not in a soft deleted state."));
+    }
+
+    @Test
+    void patchFlag_withoutToken_returns401() throws Exception {
+        String body = """
+                {
+                  "reason": "off_topic"
+                }
+                """;
+        mockMvc.perform(patch("/api/events/" + EVENT_ID + "/flag")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void patchFlag_userRole_returns403Json() throws Exception {
+        String body = """
+                {
+                  "reason": "off_topic"
+                }
+                """;
+        mockMvc.perform(patch("/api/events/" + EVENT_ID + "/flag")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.message").value("Forbidden"));
+    }
+
+    @Test
+    void patchFlag_moderatorRole_returns200() throws Exception {
+        String body = """
+                {
+                  "reason": "off_topic"
+                }
+                """;
+        mockMvc.perform(patch("/api/events/" + EVENT_ID + "/flag")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer moderator")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("flagged"))
+                .andExpect(jsonPath("$.flagReason").value("off_topic"))
+                .andExpect(jsonPath("$.flaggedBy.id").value(USER_ID.toString()));
+    }
+
+    @Test
+    void patchFlag_invalidReason_returns400Json() throws Exception {
+        String body = """
+                {
+                  "reason": "not_a_real_reason"
+                }
+                """;
+        mockMvc.perform(patch("/api/events/" + EVENT_ID + "/flag")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer moderator")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("Missing or invalid flag reason."));
+    }
+
+    @Test
+    void patchFlag_eventAlreadyFlagged_returns409Json() throws Exception {
+        String body = """
+                {
+                  "reason": "off_topic"
+                }
+                """;
+        mockMvc.perform(patch("/api/events/" + EVENT_ID_ALREADY_FLAGGED + "/flag")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer moderator")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.message").value("Event is already flagged."));
+    }
+
+    @Test
+    void patchFlag_eventNotFound_returns404Json() throws Exception {
+        String body = """
+                {
+                  "reason": "off_topic"
+                }
+                """;
+        mockMvc.perform(patch("/api/events/" + EVENT_ID_NOT_FOUND + "/flag")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer moderator")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("Event not found."));
+    }
+
+    @Test
+    void patchFlag_softDeleted_returns400Json() throws Exception {
+        String body = """
+                {
+                  "reason": "off_topic"
+                }
+                """;
+        mockMvc.perform(patch("/api/events/" + EVENT_ID_SOFT_DELETED + "/flag")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer moderator")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("Cannot flag a soft-deleted event."));
     }
 }

--- a/src/test/java/com/gatherly/gatherly_api/service/EventServiceTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/service/EventServiceTest.java
@@ -5,10 +5,12 @@ import com.gatherly.gatherly_api.dto.EventListResponse;
 import com.gatherly.gatherly_api.dto.EventResponse;
 import com.gatherly.gatherly_api.dto.UpdateEventRequest;
 import com.gatherly.gatherly_api.dto.OrganizerEventListResponse;
+import com.gatherly.gatherly_api.dto.OrganizerEventItemResponse;
 import com.gatherly.gatherly_api.model.AdmissionType;
 import com.gatherly.gatherly_api.model.Category;
 import com.gatherly.gatherly_api.model.Event;
 import com.gatherly.gatherly_api.model.EventCategory;
+import com.gatherly.gatherly_api.model.FlagReason;
 import com.gatherly.gatherly_api.model.EventStatus;
 import com.gatherly.gatherly_api.model.EventType;
 import com.gatherly.gatherly_api.model.Profile;
@@ -62,6 +64,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 class EventServiceTest {
 
     private static final UUID ORGANIZER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID MODERATOR_ID = UUID.fromString("00000000-0000-0000-0000-0000000000dd");
     private static final UUID CATEGORY_ID = UUID.fromString("00000000-0000-0000-0000-0000000000aa");
     private static final UUID SAVED_EVENT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000bb");
 
@@ -757,6 +760,144 @@ class EventServiceTest {
         ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
         verify(eventRepository).save(captor.capture());
         assertEquals(EventStatus.archived, captor.getValue().getStatus());
+    }
+
+    @Test
+    void flagEvent_whenActorRoleNotModeratorOrAdmin_throws403() {
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> eventService.flagEvent(ORGANIZER_ID, Role.user, SAVED_EVENT_ID, "off_topic")
+        );
+        assertEquals(FORBIDDEN, ex.getStatusCode());
+    }
+
+    @Test
+    void flagEvent_whenEventMissing_throws404() {
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> eventService.flagEvent(MODERATOR_ID, Role.moderator, SAVED_EVENT_ID, "off_topic")
+        );
+
+        assertEquals(NOT_FOUND, ex.getStatusCode());
+        assertEquals("Event not found.", ex.getReason());
+    }
+
+    @Test
+    void flagEvent_whenSoftDeleted_throws400() {
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+        event.setStatus(EventStatus.soft_deleted);
+        event.setDeletedAt(OffsetDateTime.now(ZoneOffset.UTC));
+
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> eventService.flagEvent(MODERATOR_ID, Role.moderator, SAVED_EVENT_ID, "off_topic")
+        );
+
+        assertEquals(BAD_REQUEST, ex.getStatusCode());
+        assertEquals("Cannot flag a soft-deleted event.", ex.getReason());
+    }
+
+    @Test
+    void flagEvent_whenAlreadyFlagged_throws409() {
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+        event.setStatus(EventStatus.flagged);
+
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> eventService.flagEvent(MODERATOR_ID, Role.moderator, SAVED_EVENT_ID, "off_topic")
+        );
+
+        assertEquals(CONFLICT, ex.getStatusCode());
+        assertEquals("Event is already flagged.", ex.getReason());
+    }
+
+    @Test
+    void flagEvent_whenReasonMissing_throws400() {
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> eventService.flagEvent(MODERATOR_ID, Role.moderator, SAVED_EVENT_ID, null)
+        );
+
+        assertEquals(BAD_REQUEST, ex.getStatusCode());
+        assertEquals("Missing or invalid flag reason.", ex.getReason());
+    }
+
+    @Test
+    void flagEvent_whenReasonInvalid_throws400() {
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> eventService.flagEvent(MODERATOR_ID, Role.moderator, SAVED_EVENT_ID, "not_a_reason")
+        );
+
+        assertEquals(BAD_REQUEST, ex.getStatusCode());
+        assertEquals("Missing or invalid flag reason.", ex.getReason());
+    }
+
+    @Test
+    void flagEvent_happyPath_setsFieldsAndReturnsResponse() {
+        Profile moderator = Profile.builder()
+                .id(MODERATOR_ID)
+                .fullName("Mod")
+                .email("mod@example.com")
+                .role(Role.moderator)
+                .avatarUrl(null)
+                .addressLine1(null)
+                .addressLine2(null)
+                .city(null)
+                .province(null)
+                .postalCode(null)
+                .createdAt(OffsetDateTime.parse("2026-01-01T00:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-01-01T00:00:00Z"))
+                .build();
+
+        Event event = persistedEventWithOrganizer(
+                persistedEvent(eventDraft("Mine", 1, 50), SAVED_EVENT_ID),
+                organizer
+        );
+
+        when(eventRepository.findById(SAVED_EVENT_ID)).thenReturn(Optional.of(event));
+        when(profileRepository.findById(MODERATOR_ID)).thenReturn(Optional.of(moderator));
+        when(eventCategoryRepository.findByEvent_Id(SAVED_EVENT_ID)).thenReturn(List.of());
+
+        when(eventRepository.save(any(Event.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        doNothing().when(entityManager).refresh(any(Event.class));
+
+        OrganizerEventItemResponse response = eventService.flagEvent(MODERATOR_ID, Role.moderator, SAVED_EVENT_ID, "off_topic");
+
+        assertEquals("flagged", response.status());
+        assertEquals("off_topic", response.flagReason());
+        assertNotNull(response.flaggedAt());
+        assertNotNull(response.flaggedBy());
+        assertEquals(MODERATOR_ID, response.flaggedBy().id());
+        assertEquals(ORGANIZER_ID, response.organizer().id());
+
+        assertEquals(EventStatus.flagged, event.getStatus());
+        assertEquals(FlagReason.off_topic, event.getFlagReason());
+        assertEquals(MODERATOR_ID, event.getFlaggedBy().getId());
     }
 
     private static CreateEventRequest validInPersonRequest(List<UUID> categoryIds) {


### PR DESCRIPTION
This commit introduces a new endpoint `PATCH /api/events/{id}/flag` in the EventController, allowing moderators and admins to flag events as inappropriate. A corresponding `FlagEventRequest` DTO is created to encapsulate the flag reason. The EventService is updated to handle the flagging logic, enforcing role-based access and validation for flag reasons. Unit tests are added to ensure proper functionality and access control, including scenarios for unauthorized access, invalid reasons, and handling of already flagged or soft-deleted events.

Closes #50 