### PR TITLE
Add cron job and function for purging soft-deleted events

### DIFF
--- a/docs/cron_purge_soft_deleted_events.md
+++ b/docs/cron_purge_soft_deleted_events.md
@@ -1,0 +1,42 @@
+# CRON — Purge soft-deleted events (7-day grace)
+
+This project uses **soft delete** for events: `DELETE /api/events/{id}` sets `events.status = 'soft_deleted'` and records `events.deleted_at`.
+
+After a **7-day grace period**, a scheduled job purges (hard-deletes) those rows.
+
+## Database behavior (cascades)
+
+Verified in Supabase (live schema):
+
+- `public.rsvps.event_id -> public.events.id` is `ON DELETE CASCADE`
+- `public.event_categories.event_id -> public.events.id` is `ON DELETE CASCADE`
+- `public.event_log.event_id -> public.events.id` was `ON DELETE RESTRICT` (this **blocked** purging)
+
+For MVP, we keep `event_log` rows even after purging an event, so we **drop the FK** from `event_log` to `events`.
+
+## Migration (applied)
+
+Migration file to commit:
+
+- `supabase/migrations/20260402190000_drop_event_log_fk_add_purge_soft_deleted_events_fn.sql`
+
+It does two things:
+
+1. Drops `event_log_event_id_fkey` so deleting an event doesn’t fail due to `RESTRICT`.
+2. Creates `public.purge_soft_deleted_events()` which deletes events where:
+   - `status = 'soft_deleted'`
+   - `deleted_at < (now() at time zone 'utc') - interval '7 days'`
+   - returns the count of deleted events
+
+## Scheduled execution
+
+We deploy a Supabase **Edge Function** named `purge-soft-deleted-events` (JWT verification disabled) that calls:
+
+- `rpc('purge_soft_deleted_events')`
+
+Repo entrypoint:
+
+- `supabase/functions/purge-soft-deleted-events/index.ts`
+
+Configure the schedule in the **Supabase Dashboard** to invoke the Edge Function on your preferred cadence (e.g. daily at `03:00` UTC).
+

--- a/supabase/functions/purge-soft-deleted-events/index.ts
+++ b/supabase/functions/purge-soft-deleted-events/index.ts
@@ -1,0 +1,38 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+type Json = Record<string, unknown>;
+
+function json(body: Json, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+Deno.serve(async (_req: Request) => {
+  const url = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+  if (!url || !serviceRoleKey) {
+    return json(
+      { ok: false, error: "Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY" },
+      500,
+    );
+  }
+
+  const supabase = createClient(url, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { data, error } = await supabase.rpc("purge_soft_deleted_events");
+  if (error) {
+    return json({ ok: false, error: error.message }, 500);
+  }
+
+  return json({ ok: true, deletedEvents: data });
+});
+

--- a/supabase/migrations/20260402190000_drop_event_log_fk_add_purge_soft_deleted_events_fn.sql
+++ b/supabase/migrations/20260402190000_drop_event_log_fk_add_purge_soft_deleted_events_fn.sql
@@ -1,0 +1,30 @@
+begin;
+
+-- Allow hard-deleting events while retaining audit rows in event_log.
+-- (We intentionally keep event_log rows even after an event is purged.)
+alter table public.event_log
+  drop constraint if exists event_log_event_id_fkey;
+
+-- Purge events that have been soft-deleted past the 7-day grace window.
+-- Returns the number of event rows removed.
+create or replace function public.purge_soft_deleted_events()
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_deleted_count integer;
+begin
+  delete from public.events e
+  where e.status = 'soft_deleted'
+    and e.deleted_at is not null
+    and e.deleted_at < (now() - interval '7 days');
+
+  get diagnostics v_deleted_count = row_count;
+  return v_deleted_count;
+end;
+$$;
+
+commit;
+


### PR DESCRIPTION
This commit introduces a new documentation file outlining the cron job for purging soft-deleted events after a 7-day grace period. It includes details on database behavior, migration scripts, and scheduled execution via a Supabase Edge Function. Additionally, a new SQL migration is added to drop the foreign key constraint from the event_log table and create a function to delete soft-deleted events. The Edge Function implementation is also included to facilitate the RPC call for purging events, enhancing data management and cleanup processes.

Closes #51 
Closes #41 
Closes #42 