### PR TITLE
Add Nixpacks configuration and update JDK version in pom.xml

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,3 @@
+# Pin JDK for Nixpacks (matches pom.xml java.version)
+[variables]
+NIXPACKS_JDK_VERSION = "21"

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,8 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>25</java.version>
+		<!-- 21 LTS: cloud builders (e.g. Railway/Nixpacks) rarely ship JDK 25 yet -->
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -110,6 +111,13 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<!-- Railway/Nixpacks runs: mvn ... -Pproduction — define profile so activation succeeds -->
+	<profiles>
+		<profile>
+			<id>production</id>
+		</profile>
+	</profiles>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
This commit introduces a new `nixpacks.toml` file to pin the JDK version to 21, aligning with the updated `pom.xml` where the Java version is also set to 21. This change ensures compatibility with cloud builders like Railway/Nixpacks, which may not support JDK 25 yet.

Fixes #78 