### PR TITLE
Add CORS configuration and update security settings

### DIFF
--- a/src/main/java/com/gatherly/gatherly_api/config/CorsConfig.java
+++ b/src/main/java/com/gatherly/gatherly_api/config/CorsConfig.java
@@ -1,0 +1,35 @@
+package com.gatherly.gatherly_api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource(
+            @Value("${app.cors.allowed-origins:http://localhost:3000}") String allowedOrigins
+    ) {
+        CorsConfiguration configuration = new CorsConfiguration();
+        List<String> origins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+        configuration.setAllowedOrigins(origins);
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));
+        configuration.setMaxAge(3600L);
+        configuration.setAllowCredentials(false);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/gatherly/gatherly_api/config/SecurityConfig.java
+++ b/src/main/java/com/gatherly/gatherly_api/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.GrantedAuthority;
@@ -103,6 +104,7 @@ public class SecurityConfig {
         http
                 // Stateless API: the client sends a token on every request.
                 .csrf(csrf -> csrf.disable())
+                .cors(Customizer.withDefaults())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(authenticationEntryPoint)
@@ -111,6 +113,8 @@ public class SecurityConfig {
                         // When the token is valid but user lacks permissions -> 403 (JSON).
                 )
                 .authorizeHttpRequests(auth -> auth
+                        // CORS preflight has no Authorization header; must not hit JWT authentication.
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",

--- a/src/main/resources/application-example.properties
+++ b/src/main/resources/application-example.properties
@@ -21,6 +21,13 @@
 #
 #   SUPABASE_ISSUER_URI=https://<project-ref>.supabase.co/auth/v1
 #
+# CORS (browser clients): comma-separated origins. If unset, defaults to http://localhost:3000.
+# When the frontend is deployed, append its origin, e.g.:
+#   CORS_ALLOWED_ORIGINS=http://localhost:3000,https://your-frontend.example.com
+#
+# application-prod.properties sets server.forward-headers-strategy=framework so Swagger
+# "Try it out" uses https:// behind Railway (avoids mixed http/https).
+#
 # PORT is set by Railway; server.port reads it via application-prod.properties.
 #
 # Transaction pooler (6543) needs prepareThreshold=0 on the JDBC URL or the driver

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,6 +1,9 @@
 # Activated when SPRING_PROFILES_ACTIVE includes prod (e.g. Railway).
 # Datasource uses the same SPRING_DATASOURCE_* env vars as application.properties.
 
+# Railway terminates TLS; honor X-Forwarded-* so Swagger/OpenAPI use https:// for "Try it out".
+server.forward-headers-strategy=framework
+
 server.port=${PORT:8080}
 
 # Supabase Auth JWT (OIDC issuer). No default — misconfiguration fails fast.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,6 @@ spring.jpa.hibernate.ddl-auto=validate
 # Set spring.security.oauth2.resourceserver.jwt.issuer-uri in application-local.properties,
 # or set SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI (Spring Boot env binding).
 # Production: application-prod.properties sets issuer from SUPABASE_ISSUER_URI.
+
+# Comma-separated browser origins; default includes local frontend. Override via CORS_ALLOWED_ORIGINS in Railway.
+app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:3000}

--- a/src/test/java/com/gatherly/gatherly_api/controller/CategoryControllerTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/controller/CategoryControllerTest.java
@@ -1,5 +1,6 @@
 package com.gatherly.gatherly_api.controller;
 
+import com.gatherly.gatherly_api.config.CorsConfig;
 import com.gatherly.gatherly_api.config.SecurityConfig;
 import com.gatherly.gatherly_api.model.Category;
 import com.gatherly.gatherly_api.service.CategoryService;
@@ -9,6 +10,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -23,12 +25,14 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(CategoryController.class)
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, CorsConfig.class})
 @Execution(ExecutionMode.SAME_THREAD)
 class CategoryControllerTest {
 
@@ -90,6 +94,15 @@ class CategoryControllerTest {
                         .build();
             };
         }
+    }
+
+    @Test
+    void optionsApiCategories_preflight_includesAllowOriginForLocalFrontend() throws Exception {
+        mockMvc.perform(options("/api/categories")
+                        .header(HttpHeaders.ORIGIN, "http://localhost:3000")
+                        .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://localhost:3000"));
     }
 
     @Test

--- a/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/controller/EventControllerTest.java
@@ -1,5 +1,6 @@
 package com.gatherly.gatherly_api.controller;
 
+import com.gatherly.gatherly_api.config.CorsConfig;
 import com.gatherly.gatherly_api.config.SecurityConfig;
 import com.gatherly.gatherly_api.dto.CreateEventRequest;
 import com.gatherly.gatherly_api.dto.EventAddressResponse;
@@ -46,7 +47,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(EventController.class)
-@Import({SecurityConfig.class, GlobalExceptionHandler.class})
+@Import({SecurityConfig.class, CorsConfig.class, GlobalExceptionHandler.class})
 class EventControllerTest {
 
     private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");

--- a/src/test/java/com/gatherly/gatherly_api/controller/ProfileControllerTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/controller/ProfileControllerTest.java
@@ -1,5 +1,6 @@
 package com.gatherly.gatherly_api.controller;
 
+import com.gatherly.gatherly_api.config.CorsConfig;
 import com.gatherly.gatherly_api.config.SecurityConfig;
 import com.gatherly.gatherly_api.dto.UpdateMyProfileRequest;
 import com.gatherly.gatherly_api.model.Profile;
@@ -32,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProfileController.class)
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, CorsConfig.class})
 class ProfileControllerTest {
 
     private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");

--- a/src/test/java/com/gatherly/gatherly_api/controller/RsvpControllerTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/controller/RsvpControllerTest.java
@@ -1,5 +1,6 @@
 package com.gatherly.gatherly_api.controller;
 
+import com.gatherly.gatherly_api.config.CorsConfig;
 import com.gatherly.gatherly_api.config.SecurityConfig;
 import com.gatherly.gatherly_api.dto.MyRsvpsResponse;
 import com.gatherly.gatherly_api.dto.PageResponse;
@@ -32,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(RsvpController.class)
-@Import({SecurityConfig.class, GlobalExceptionHandler.class})
+@Import({SecurityConfig.class, CorsConfig.class, GlobalExceptionHandler.class})
 class RsvpControllerTest {
 
     private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");

--- a/src/test/java/com/gatherly/gatherly_api/security/SecurityErrorResponsesTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/security/SecurityErrorResponsesTest.java
@@ -1,5 +1,7 @@
 package com.gatherly.gatherly_api.security;
 
+import com.gatherly.gatherly_api.config.CorsConfig;
+import com.gatherly.gatherly_api.config.SecurityConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -21,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProtectedHelloController.class)
-@Import(com.gatherly.gatherly_api.config.SecurityConfig.class)
+@Import({SecurityConfig.class, CorsConfig.class})
 class SecurityErrorResponsesTest {
 
     @Autowired


### PR DESCRIPTION
This commit introduces a new `CorsConfig` class to manage CORS settings, allowing specified origins and HTTP methods for cross-origin requests. The `SecurityConfig` class is updated to enable CORS support and permit OPTIONS requests, ensuring proper handling of preflight requests. Additionally, configuration properties for allowed origins are added to `application.properties` and `application-example.properties`. Unit tests are also updated to include CORS-related scenarios for various controllers, enhancing the application's security and interoperability with frontend clients.

Closes #80 