### PR TITLE
Enhance event creation and update API documentation

### DIFF
--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -273,7 +273,15 @@ Returns the full list of available event categories.
 #### `POST /events`
 Creates a new event. The authenticated user becomes the organizer.
 
-**Request body:**
+**Request body:** Shape depends on `eventType`:
+
+- **`virtual`:** `meetingLink` is required. Address fields may be omitted or null. Swagger UI lists named examples (**Virtual**, **InPerson**, **Hybrid**).
+- **`in_person`:** `addressLine1`, `city`, `province`, and `postalCode` are required. `meetingLink` may be omitted or null.
+- **`hybrid`:** Both `meetingLink` and the same address fields as in-person are required.
+
+**URL fields:** When `meetingLink` or `coverImageUrl` is non-empty, it must be a valid **`http` or `https` URL with a host** (otherwise the API returns `400` with a message like `meetingLink must be a valid http or https URL.`).
+
+**Example — in-person (free):**
 ```json
 {
   "title": "Spring Meetup 2026",
@@ -290,9 +298,32 @@ Creates a new event. The authenticated user becomes the organizer.
   "postalCode": "M5V 1A1",
   "meetingLink": null,
   "admissionFee": null,
-  "coverImageUrl": "https://res.cloudinary.com/...",
+  "coverImageUrl": "https://cdn.example.com/events/banner.jpg",
   "maxCapacity": 50,
   "categoryIds": ["uuid", "uuid"]
+}
+```
+
+**Example — virtual (free):**
+```json
+{
+  "title": "Online AMA",
+  "description": "<p>Join from anywhere</p>",
+  "eventType": "virtual",
+  "admissionType": "free",
+  "startTime": "2026-04-02T18:00:00Z",
+  "endTime": "2026-04-02T19:30:00Z",
+  "timezone": "America/Toronto",
+  "addressLine1": null,
+  "addressLine2": null,
+  "city": null,
+  "province": null,
+  "postalCode": null,
+  "meetingLink": "https://meet.example.com/room/abc",
+  "admissionFee": null,
+  "coverImageUrl": null,
+  "maxCapacity": 100,
+  "categoryIds": []
 }
 ```
 
@@ -301,7 +332,7 @@ Creates a new event. The authenticated user becomes the organizer.
 | Status | Description |
 |---|---|
 | `201 Created` | Event created successfully. Returns the created event. |
-| `400 Bad Request` | Validation failed (e.g. missing required fields, end time before start time, more than 3 categories, missing meeting link for virtual event, `admissionFee` provided for a free event, `admissionFee` missing or zero for a paid event). |
+| `400 Bad Request` | Validation failed (e.g. missing required fields, end time before start time, more than 3 categories, missing meeting link for virtual or hybrid, missing address for in-person or hybrid, invalid or non-http(s) `meetingLink` / `coverImageUrl`, `admissionFee` provided for a free event, `admissionFee` missing or zero for a paid event). |
 | `401 Unauthorized` | Missing or invalid token. |
 
 ---
@@ -315,14 +346,14 @@ Updates an existing event. Only the organizer can edit their own event. `eventTy
 |---|---|---|
 | `id` | `UUID` | The event ID. |
 
-**Request body:** Same shape as `POST /events` excluding `eventType`, `admissionType` and `admissionFee`.
+**Request body:** Same shape as `POST /events` excluding `eventType`, `admissionType` and `admissionFee`. Location and link requirements follow the **stored** event type (virtual / in_person / hybrid), same rules as create. Non-empty `meetingLink` and `coverImageUrl` must be valid **`http` or `https` URLs with a host**. OpenAPI includes named examples (**Virtual**, **InPerson**, **Hybrid**) for this body.
 
 **Responses:**
 
 | Status | Description |
 |---|---|
 | `200 OK` | Event updated successfully. Returns the updated event. |
-| `400 Bad Request` | Validation failed. |
+| `400 Bad Request` | Validation failed (including invalid URLs or missing link/address for the event’s type). |
 | `401 Unauthorized` | Missing or invalid token. |
 | `403 Forbidden` | Authenticated user is not the organizer. |
 | `404 Not Found` | Event not found. |

--- a/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
+++ b/src/main/java/com/gatherly/gatherly_api/controller/EventController.java
@@ -235,7 +235,93 @@ public class EventController {
     )
     public ResponseEntity<EventResponse> createEvent(
             @AuthenticationPrincipal Jwt jwt,
-            @Valid @RequestBody CreateEventRequest request
+            @Valid
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Shape depends on eventType: virtual needs meetingLink; in_person needs address fields; "
+                            + "hybrid needs both. See named examples.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CreateEventRequest.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "Virtual",
+                                            summary = "Free virtual event",
+                                            value = """
+                                                    {
+                                                      "title": "Spring Meetup 2026",
+                                                      "description": "<p>Online meetup</p>",
+                                                      "eventType": "virtual",
+                                                      "admissionType": "free",
+                                                      "startTime": "2026-04-01T18:00:00Z",
+                                                      "endTime": "2026-04-01T21:00:00Z",
+                                                      "timezone": "America/Toronto",
+                                                      "addressLine1": null,
+                                                      "addressLine2": null,
+                                                      "city": null,
+                                                      "province": null,
+                                                      "postalCode": null,
+                                                      "meetingLink": "https://meet.example.com/room/abc",
+                                                      "coverImageUrl": "https://cdn.example.com/events/banner.jpg",
+                                                      "admissionFee": null,
+                                                      "maxCapacity": 50,
+                                                      "categoryIds": []
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "InPerson",
+                                            summary = "Free in-person event",
+                                            value = """
+                                                    {
+                                                      "title": "Neighborhood Walk",
+                                                      "description": "<p>Meet at the corner</p>",
+                                                      "eventType": "in_person",
+                                                      "admissionType": "free",
+                                                      "startTime": "2026-04-10T14:00:00Z",
+                                                      "endTime": "2026-04-10T16:00:00Z",
+                                                      "timezone": "America/Toronto",
+                                                      "addressLine1": "123 Main St",
+                                                      "addressLine2": null,
+                                                      "city": "Toronto",
+                                                      "province": "ON",
+                                                      "postalCode": "M5V 1A1",
+                                                      "meetingLink": null,
+                                                      "coverImageUrl": null,
+                                                      "admissionFee": null,
+                                                      "maxCapacity": 30,
+                                                      "categoryIds": []
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "Hybrid",
+                                            summary = "Free hybrid event",
+                                            value = """
+                                                    {
+                                                      "title": "Workshop + stream",
+                                                      "description": "<p>Attend in person or online</p>",
+                                                      "eventType": "hybrid",
+                                                      "admissionType": "free",
+                                                      "startTime": "2026-05-01T17:00:00Z",
+                                                      "endTime": "2026-05-01T20:00:00Z",
+                                                      "timezone": "America/Toronto",
+                                                      "addressLine1": "456 Queen St W",
+                                                      "addressLine2": "Suite 200",
+                                                      "city": "Toronto",
+                                                      "province": "ON",
+                                                      "postalCode": "M5V 2A8",
+                                                      "meetingLink": "https://meet.example.com/room/hybrid",
+                                                      "coverImageUrl": "https://cdn.example.com/events/workshop.jpg",
+                                                      "admissionFee": null,
+                                                      "maxCapacity": 100,
+                                                      "categoryIds": []
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+            @RequestBody CreateEventRequest request
     ) {
         UUID organizerId = readUserIdFromJwt(jwt);
         EventResponse body = eventService.createEvent(organizerId, request);
@@ -325,7 +411,84 @@ public class EventController {
     public ResponseEntity<EventResponse> updateEvent(
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable UUID id,
-            @Valid @RequestBody UpdateEventRequest request
+            @Valid
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Same mutable fields as create, without eventType, admissionType, or admissionFee. "
+                            + "Rules depend on the event's stored type — see named examples.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = UpdateEventRequest.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "Virtual",
+                                            summary = "Update body when event is virtual",
+                                            value = """
+                                                    {
+                                                      "title": "Spring Meetup 2026",
+                                                      "description": "<p>Updated details</p>",
+                                                      "startTime": "2026-04-01T18:00:00Z",
+                                                      "endTime": "2026-04-01T21:00:00Z",
+                                                      "timezone": "America/Toronto",
+                                                      "addressLine1": null,
+                                                      "addressLine2": null,
+                                                      "city": null,
+                                                      "province": null,
+                                                      "postalCode": null,
+                                                      "meetingLink": "https://meet.example.com/room/abc",
+                                                      "coverImageUrl": "https://cdn.example.com/events/banner.jpg",
+                                                      "maxCapacity": 50,
+                                                      "categoryIds": []
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "InPerson",
+                                            summary = "Update body when event is in_person",
+                                            value = """
+                                                    {
+                                                      "title": "Neighborhood Walk",
+                                                      "description": "<p>Updated route</p>",
+                                                      "startTime": "2026-04-10T14:00:00Z",
+                                                      "endTime": "2026-04-10T16:00:00Z",
+                                                      "timezone": "America/Toronto",
+                                                      "addressLine1": "123 Main St",
+                                                      "addressLine2": null,
+                                                      "city": "Toronto",
+                                                      "province": "ON",
+                                                      "postalCode": "M5V 1A1",
+                                                      "meetingLink": null,
+                                                      "coverImageUrl": null,
+                                                      "maxCapacity": 30,
+                                                      "categoryIds": []
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "Hybrid",
+                                            summary = "Update body when event is hybrid",
+                                            value = """
+                                                    {
+                                                      "title": "Workshop + stream",
+                                                      "description": "<p>Updated schedule</p>",
+                                                      "startTime": "2026-05-01T17:00:00Z",
+                                                      "endTime": "2026-05-01T20:00:00Z",
+                                                      "timezone": "America/Toronto",
+                                                      "addressLine1": "456 Queen St W",
+                                                      "addressLine2": "Suite 200",
+                                                      "city": "Toronto",
+                                                      "province": "ON",
+                                                      "postalCode": "M5V 2A8",
+                                                      "meetingLink": "https://meet.example.com/room/hybrid",
+                                                      "coverImageUrl": "https://cdn.example.com/events/workshop.jpg",
+                                                      "maxCapacity": 100,
+                                                      "categoryIds": []
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+            @RequestBody UpdateEventRequest request
     ) {
         UUID organizerId = readUserIdFromJwt(jwt);
         return ResponseEntity.ok(eventService.updateEvent(organizerId, id, request));

--- a/src/main/java/com/gatherly/gatherly_api/dto/CreateEventRequest.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/CreateEventRequest.java
@@ -4,6 +4,8 @@ import com.gatherly.gatherly_api.model.AdmissionType;
 import com.gatherly.gatherly_api.model.EventType;
 import com.gatherly.gatherly_api.model.Province;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -21,6 +23,13 @@ import java.util.UUID;
  * on several fields together — for example “virtual events need a meeting link” — are checked
  * in {@link com.gatherly.gatherly_api.service.EventService} so we can return clear error text.
  */
+@Schema(
+        description = "Bean Validation covers simple fields. The service also enforces: endTime after startTime; "
+                + "at most three unique categoryIds; free events omit admissionFee, paid events require "
+                + "admissionFee greater than zero; virtual and hybrid events require meetingLink; in_person and hybrid "
+                + "require addressLine1, city, province, and postalCode; when non-blank, meetingLink and "
+                + "coverImageUrl must be http or https URLs with a host."
+)
 public record CreateEventRequest(
         @NotBlank @Size(max = 150) String title,
         @NotBlank String description,
@@ -34,7 +43,18 @@ public record CreateEventRequest(
         @Size(max = 100) String city,
         Province province,
         @Size(max = 7) String postalCode,
+        @Schema(
+                description = "Required for virtual and hybrid events. When provided, must be http or https with a host.",
+                example = "https://meet.example.com/room/abc",
+                format = "uri"
+        )
         String meetingLink,
+        @Schema(
+                description = "Optional. When provided, must be http or https with a host.",
+                example = "https://cdn.example.com/events/banner.jpg",
+                format = "uri",
+                nullable = true
+        )
         String coverImageUrl,
         BigDecimal admissionFee,
         @NotNull @Positive Integer maxCapacity,

--- a/src/main/java/com/gatherly/gatherly_api/dto/FlagEventRequest.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/FlagEventRequest.java
@@ -1,5 +1,7 @@
 package com.gatherly.gatherly_api.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Request body for {@code PATCH /api/events/{id}/flag}.
  *
@@ -8,6 +10,13 @@ package com.gatherly.gatherly_api.dto;
  *
  * <p>Authorization (moderator/admin) is enforced by the controller/service.
  */
-public record FlagEventRequest(String reason) {
+public record FlagEventRequest(
+        @Schema(
+                description = "Flag reason label (lowercase, as stored in the database).",
+                example = "spam",
+                allowableValues = { "off_topic", "nsfw", "spam", "misleading", "other" }
+        )
+        String reason
+) {
 }
 

--- a/src/main/java/com/gatherly/gatherly_api/dto/UpdateEventRequest.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/UpdateEventRequest.java
@@ -2,6 +2,8 @@ package com.gatherly.gatherly_api.dto;
 
 import com.gatherly.gatherly_api.model.Province;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -18,6 +20,12 @@ import java.util.UUID;
  * {@code admissionType}, or {@code admissionFee} — those are fixed at creation (see database triggers).
  * Cross-field rules (virtual needs a link, etc.) live in {@link com.gatherly.gatherly_api.service.EventService}.
  */
+@Schema(
+        description = "Event type and admission are fixed after creation. The service enforces the same "
+                + "location/link rules against the stored event type: virtual and hybrid need meetingLink; "
+                + "in_person and hybrid need addressLine1, city, province, and postalCode. When non-blank, "
+                + "meetingLink and coverImageUrl must be http or https URLs with a host."
+)
 public record UpdateEventRequest(
         @NotBlank @Size(max = 150) String title,
         @NotBlank String description,
@@ -29,7 +37,19 @@ public record UpdateEventRequest(
         @Size(max = 100) String city,
         Province province,
         @Size(max = 7) String postalCode,
+        @Schema(
+                description = "Required for virtual and hybrid events (per stored event type). "
+                        + "When provided, must be http or https with a host.",
+                example = "https://meet.example.com/room/abc",
+                format = "uri"
+        )
         String meetingLink,
+        @Schema(
+                description = "Optional. When provided, must be http or https with a host.",
+                example = "https://cdn.example.com/events/banner.jpg",
+                format = "uri",
+                nullable = true
+        )
         String coverImageUrl,
         @NotNull @Positive Integer maxCapacity,
         @Size(max = 3) List<UUID> categoryIds

--- a/src/main/java/com/gatherly/gatherly_api/dto/UpdateMyProfileRequest.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/UpdateMyProfileRequest.java
@@ -1,5 +1,7 @@
 package com.gatherly.gatherly_api.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -12,6 +14,12 @@ public record UpdateMyProfileRequest(
         @Size(max = 100, message = "fullName must be at most 100 characters.")
         String fullName,
 
+        @Schema(
+                description = "Optional. Empty or a valid http or https URL.",
+                example = "https://cdn.example.com/avatar.jpg",
+                format = "uri",
+                nullable = true
+        )
         @Pattern(
                 regexp = "^(https?://.*)?$",
                 message = "avatarUrl must be a valid http/https URL."


### PR DESCRIPTION
This commit updates the API documentation for event creation and updates, clarifying the request body requirements based on event types (virtual, in-person, hybrid). It includes detailed examples for each event type and specifies URL validation for `meetingLink` and `coverImageUrl`. Additionally, the `CreateEventRequest` and `UpdateEventRequest` DTOs are enhanced with Swagger annotations to improve API documentation clarity and enforce validation rules. This change aims to provide better guidance for API consumers and ensure correct data submission.

Closes #82 