### PR TITLE
Add admin user management functionality

### DIFF
--- a/src/main/java/com/gatherly/gatherly_api/config/SecurityConfig.java
+++ b/src/main/java/com/gatherly/gatherly_api/config/SecurityConfig.java
@@ -125,6 +125,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/events").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/events/my").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/events/*").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 // Validate JWTs for any endpoint that requires authentication.

--- a/src/main/java/com/gatherly/gatherly_api/controller/AdminUserController.java
+++ b/src/main/java/com/gatherly/gatherly_api/controller/AdminUserController.java
@@ -1,0 +1,62 @@
+package com.gatherly.gatherly_api.controller;
+
+import com.gatherly.gatherly_api.dto.PatchUserRoleRequest;
+import com.gatherly.gatherly_api.dto.ProfileResponse;
+import com.gatherly.gatherly_api.model.Profile;
+import com.gatherly.gatherly_api.service.AdminUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/admin/users")
+@Tag(name = "Admin — Users", description = "Admin-only user management")
+@SecurityRequirement(name = "bearerAuth")
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    public AdminUserController(AdminUserService adminUserService) {
+        this.adminUserService = adminUserService;
+    }
+
+    @PatchMapping("/{id}/role")
+    @Operation(
+            summary = "Change user role (user or moderator)",
+            description = "Promotes or demotes a user between user and moderator. Cannot assign or change the admin role.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Role updated successfully.",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ProfileResponse.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "400", description = "Invalid role or cannot change admin account."),
+                    @ApiResponse(responseCode = "401", description = "Missing or invalid token."),
+                    @ApiResponse(responseCode = "403", description = "Authenticated user is not admin."),
+                    @ApiResponse(responseCode = "404", description = "User not found.")
+            }
+    )
+    public ResponseEntity<ProfileResponse> patchUserRole(
+            @Parameter(description = "User ID") @PathVariable("id") UUID id,
+            @Valid @RequestBody PatchUserRoleRequest request
+    ) {
+        Profile updated = adminUserService.updateUserRole(id, request);
+        return ResponseEntity.ok(ProfileResponse.from(updated));
+    }
+}

--- a/src/main/java/com/gatherly/gatherly_api/dto/PatchUserRoleRequest.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/PatchUserRoleRequest.java
@@ -1,0 +1,16 @@
+package com.gatherly.gatherly_api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "Promote or demote a user between user and moderator.")
+public record PatchUserRoleRequest(
+        @NotNull
+        @Schema(
+                description = "Target role (cannot be admin).",
+                example = "moderator",
+                allowableValues = {"user", "moderator"}
+        )
+        PromotableRole role
+) {
+}

--- a/src/main/java/com/gatherly/gatherly_api/dto/PromotableRole.java
+++ b/src/main/java/com/gatherly/gatherly_api/dto/PromotableRole.java
@@ -1,0 +1,9 @@
+package com.gatherly.gatherly_api.dto;
+
+/**
+ * Roles that can be assigned via {@code PATCH /api/admin/users/{id}/role} (user or moderator only).
+ */
+public enum PromotableRole {
+    user,
+    moderator
+}

--- a/src/main/java/com/gatherly/gatherly_api/model/Profile.java
+++ b/src/main/java/com/gatherly/gatherly_api/model/Profile.java
@@ -92,4 +92,9 @@ public class Profile {
         this.province = (province == null || province.isBlank()) ? null : Province.valueOf(province);
         this.postalCode = postalCode;
     }
+
+    /** Updates role for admin-only flows (e.g. promote/demote moderator). */
+    public void applyRole(Role newRole) {
+        this.role = newRole;
+    }
 }

--- a/src/main/java/com/gatherly/gatherly_api/service/AdminUserService.java
+++ b/src/main/java/com/gatherly/gatherly_api/service/AdminUserService.java
@@ -1,0 +1,40 @@
+package com.gatherly.gatherly_api.service;
+
+import com.gatherly.gatherly_api.dto.PatchUserRoleRequest;
+import com.gatherly.gatherly_api.model.Profile;
+import com.gatherly.gatherly_api.model.Role;
+import com.gatherly.gatherly_api.repository.ProfileRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+@Service
+public class AdminUserService {
+
+    private final ProfileRepository profileRepository;
+
+    public AdminUserService(ProfileRepository profileRepository) {
+        this.profileRepository = profileRepository;
+    }
+
+    /**
+     * Sets a user's role to {@code user} or {@code moderator} only. Cannot change accounts whose current role is {@code admin}.
+     */
+    public Profile updateUserRole(UUID targetUserId, PatchUserRoleRequest request) {
+        Profile profile = profileRepository.findById(targetUserId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found."));
+
+        if (profile.getRole() == Role.admin) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Cannot change role for an admin account via this endpoint."
+            );
+        }
+
+        Role newRole = Role.valueOf(request.role().name());
+        profile.applyRole(newRole);
+        return profileRepository.save(profile);
+    }
+}

--- a/src/test/java/com/gatherly/gatherly_api/controller/AdminUserControllerTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/controller/AdminUserControllerTest.java
@@ -1,0 +1,170 @@
+package com.gatherly.gatherly_api.controller;
+
+import com.gatherly.gatherly_api.config.CorsConfig;
+import com.gatherly.gatherly_api.config.SecurityConfig;
+import com.gatherly.gatherly_api.dto.PatchUserRoleRequest;
+import com.gatherly.gatherly_api.model.Profile;
+import com.gatherly.gatherly_api.model.Role;
+import com.gatherly.gatherly_api.service.AdminUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminUserController.class)
+@Import({SecurityConfig.class, CorsConfig.class})
+class AdminUserControllerTest {
+
+    private static final UUID TARGET_USER_ID = UUID.fromString("00000000-0000-0000-0000-0000000000aa");
+
+    private static final AtomicReference<RuntimeException> SERVICE_ERROR = new AtomicReference<>();
+    private static final AtomicReference<Profile> SERVICE_RESULT = new AtomicReference<>();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void resetStub() {
+        SERVICE_ERROR.set(null);
+        SERVICE_RESULT.set(null);
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        AdminUserService adminUserService() {
+            return new AdminUserService(null) {
+                @Override
+                public Profile updateUserRole(UUID targetUserId, PatchUserRoleRequest request) {
+                    RuntimeException err = SERVICE_ERROR.get();
+                    if (err != null) {
+                        throw err;
+                    }
+                    return SERVICE_RESULT.get();
+                }
+            };
+        }
+
+        @Bean
+        JwtDecoder jwtDecoder() {
+            return tokenValue -> {
+                if ("invalid".equals(tokenValue)) {
+                    throw new org.springframework.security.oauth2.core.OAuth2AuthenticationException(
+                            new org.springframework.security.oauth2.core.OAuth2Error("invalid_token"),
+                            "Invalid token"
+                    );
+                }
+                String role = switch (tokenValue) {
+                    case "admin" -> "admin";
+                    case "user" -> "user";
+                    default -> "user";
+                };
+                Instant now = Instant.now();
+                return Jwt.withTokenValue(tokenValue)
+                        .header("alg", "RS256")
+                        .subject("00000000-0000-0000-0000-000000000099")
+                        .claim("role", role)
+                        .issuedAt(now)
+                        .expiresAt(now.plusSeconds(3600))
+                        .build();
+            };
+        }
+    }
+
+    @Test
+    void patchRole_withAdminToken_returns200() throws Exception {
+        Profile updated = Profile.builder()
+                .id(TARGET_USER_ID)
+                .fullName("Jane Doe")
+                .email("jane@example.com")
+                .role(Role.moderator)
+                .avatarUrl(null)
+                .addressLine1(null)
+                .addressLine2(null)
+                .city(null)
+                .province(null)
+                .postalCode(null)
+                .createdAt(OffsetDateTime.parse("2026-03-18T10:00:00Z"))
+                .updatedAt(OffsetDateTime.parse("2026-03-18T10:00:00Z"))
+                .build();
+        SERVICE_RESULT.set(updated);
+
+        mockMvc.perform(patch("/api/admin/users/{id}/role", TARGET_USER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer admin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"role\": \"moderator\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(TARGET_USER_ID.toString()))
+                .andExpect(jsonPath("$.role").value("moderator"));
+    }
+
+    @Test
+    void patchRole_withUserToken_returns403() throws Exception {
+        mockMvc.perform(patch("/api/admin/users/{id}/role", TARGET_USER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer user")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"role\": \"moderator\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void patchRole_missingToken_returns401() throws Exception {
+        mockMvc.perform(patch("/api/admin/users/{id}/role", TARGET_USER_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"role\": \"moderator\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void patchRole_invalidToken_returns401() throws Exception {
+        mockMvc.perform(patch("/api/admin/users/{id}/role", TARGET_USER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer invalid")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"role\": \"moderator\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void patchRole_whenNotFound_returns404() throws Exception {
+        SERVICE_ERROR.set(new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found."));
+
+        mockMvc.perform(patch("/api/admin/users/{id}/role", TARGET_USER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer admin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"role\": \"moderator\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void patchRole_whenTargetIsAdmin_returns400() throws Exception {
+        SERVICE_ERROR.set(new ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "Cannot change role for an admin account via this endpoint."
+        ));
+
+        mockMvc.perform(patch("/api/admin/users/{id}/role", TARGET_USER_ID)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer admin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"role\": \"moderator\"}"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/gatherly/gatherly_api/service/AdminUserServiceTest.java
+++ b/src/test/java/com/gatherly/gatherly_api/service/AdminUserServiceTest.java
@@ -1,0 +1,102 @@
+package com.gatherly.gatherly_api.service;
+
+import com.gatherly.gatherly_api.dto.PatchUserRoleRequest;
+import com.gatherly.gatherly_api.dto.PromotableRole;
+import com.gatherly.gatherly_api.model.Profile;
+import com.gatherly.gatherly_api.model.Role;
+import com.gatherly.gatherly_api.repository.ProfileRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@ExtendWith(MockitoExtension.class)
+class AdminUserServiceTest {
+
+    @Mock
+    private ProfileRepository profileRepository;
+
+    @InjectMocks
+    private AdminUserService adminUserService;
+
+    @Test
+    void updateUserRole_promotesUserToModerator() {
+        UUID id = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        Profile existing = Profile.builder()
+                .id(id)
+                .fullName("A")
+                .email("a@example.com")
+                .role(Role.user)
+                .build();
+        when(profileRepository.findById(id)).thenReturn(Optional.of(existing));
+        when(profileRepository.save(any(Profile.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Profile result = adminUserService.updateUserRole(id, new PatchUserRoleRequest(PromotableRole.moderator));
+
+        assertEquals(Role.moderator, result.getRole());
+        ArgumentCaptor<Profile> captor = ArgumentCaptor.forClass(Profile.class);
+        verify(profileRepository).save(captor.capture());
+        assertEquals(Role.moderator, captor.getValue().getRole());
+    }
+
+    @Test
+    void updateUserRole_demotesModeratorToUser() {
+        UUID id = UUID.fromString("00000000-0000-0000-0000-000000000002");
+        Profile existing = Profile.builder()
+                .id(id)
+                .fullName("B")
+                .email("b@example.com")
+                .role(Role.moderator)
+                .build();
+        when(profileRepository.findById(id)).thenReturn(Optional.of(existing));
+        when(profileRepository.save(any(Profile.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Profile result = adminUserService.updateUserRole(id, new PatchUserRoleRequest(PromotableRole.user));
+
+        assertEquals(Role.user, result.getRole());
+    }
+
+    @Test
+    void updateUserRole_whenMissing_throws404() {
+        UUID id = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        when(profileRepository.findById(id)).thenReturn(Optional.empty());
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> adminUserService.updateUserRole(id, new PatchUserRoleRequest(PromotableRole.moderator))
+        );
+        assertEquals(NOT_FOUND, ex.getStatusCode());
+    }
+
+    @Test
+    void updateUserRole_whenTargetIsAdmin_throws400() {
+        UUID id = UUID.fromString("00000000-0000-0000-0000-000000000004");
+        Profile existing = Profile.builder()
+                .id(id)
+                .fullName("Admin")
+                .email("admin@example.com")
+                .role(Role.admin)
+                .build();
+        when(profileRepository.findById(id)).thenReturn(Optional.of(existing));
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> adminUserService.updateUserRole(id, new PatchUserRoleRequest(PromotableRole.moderator))
+        );
+        assertEquals(BAD_REQUEST, ex.getStatusCode());
+    }
+}


### PR DESCRIPTION
This commit introduces an `AdminUserController` for managing user roles, allowing admins to promote or demote users between 'user' and 'moderator' roles. It includes a new `PatchUserRoleRequest` DTO for role updates and a corresponding `AdminUserService` to handle the business logic. Security configurations are updated to restrict access to admin endpoints, and unit tests are added to ensure proper functionality and error handling for the new features.

Closes #86 