### PR TITLE
Enhance event retrieval logic to prevent integer overflow in Postgres

### DIFF
--- a/src/main/java/com/gatherly/gatherly_api/repository/EventRepository.java
+++ b/src/main/java/com/gatherly/gatherly_api/repository/EventRepository.java
@@ -33,7 +33,8 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
                     WHERE e.status = 'active'
                     ORDER BY
                       CASE
-                        WHEN (COALESCE(e.rsvp_count, 0) * 100) >= (e.max_capacity * 80) THEN 1
+                        -- Use BIGINT math to avoid integer overflow in Postgres.
+                        WHEN (COALESCE(e.rsvp_count, 0)::bigint * 100) >= (e.max_capacity::bigint * 80) THEN 1
                         ELSE 0
                       END DESC,
                       e.start_time ASC,


### PR DESCRIPTION
This commit modifies the event retrieval query in the `EventRepository` to use BIGINT math for the RSVP count and max capacity calculations. This change prevents potential integer overflow issues in PostgreSQL, ensuring accurate event status evaluation during retrieval.

Fixes #91 